### PR TITLE
upgrade bs-platform to v4.0.1

### DIFF
--- a/lib/js/__tests__/Aeson_decode_test.js
+++ b/lib/js/__tests__/Aeson_decode_test.js
@@ -44,11 +44,11 @@ function throws(_$staropt$star, decoder, _param) {
   while(true) {
     var param = _param;
     var $staropt$star = _$staropt$star;
-    var prefix = $staropt$star ? $staropt$star[0] : "";
+    var prefix = $staropt$star !== undefined ? $staropt$star : "";
     if (param) {
       test(decoder, prefix, param[0]);
       _param = param[1];
-      _$staropt$star = /* Some */[prefix];
+      _$staropt$star = prefix;
       continue ;
     } else {
       return /* () */0;
@@ -68,7 +68,7 @@ describe("bool", (function () {
         Jest.test("bool - false", (function () {
                 return Jest.Expect[/* toEqual */12](false, Jest.Expect[/* expect */0](Aeson_decode.bool(false)));
               }));
-        return throws(/* None */0, Aeson_decode.bool, /* :: */[
+        return throws(undefined, Aeson_decode.bool, /* :: */[
                     /* Float */0,
                     /* :: */[
                       /* Int */1,
@@ -96,7 +96,7 @@ describe("float", (function () {
         Jest.test("int", (function () {
                 return Jest.Expect[/* toEqual */12](23, Jest.Expect[/* expect */0](Aeson_decode.$$float(23)));
               }));
-        return throws(/* None */0, Aeson_decode.$$float, /* :: */[
+        return throws(undefined, Aeson_decode.$$float, /* :: */[
                     /* Bool */6,
                     /* :: */[
                       /* String */2,
@@ -122,7 +122,7 @@ describe("int", (function () {
                 var big_int = (2147483648);
                 return Jest.Expect[/* toEqual */12](big_int, Jest.Expect[/* expect */0](Aeson_decode.$$int(big_int)));
               }));
-        return throws(/* None */0, Aeson_decode.$$int, /* :: */[
+        return throws(undefined, Aeson_decode.$$int, /* :: */[
                     /* Bool */6,
                     /* :: */[
                       /* Float */0,
@@ -204,7 +204,7 @@ describe("string", (function () {
         Jest.test("string", (function () {
                 return Jest.Expect[/* toEqual */12]("test", Jest.Expect[/* expect */0](Aeson_decode.string("test")));
               }));
-        return throws(/* None */0, Aeson_decode.string, /* :: */[
+        return throws(undefined, Aeson_decode.string, /* :: */[
                     /* Bool */6,
                     /* :: */[
                       /* Float */0,
@@ -254,7 +254,7 @@ describe("nullable", (function () {
                                       return Aeson_decode.nullAs(partial_arg, param);
                                     }), null)));
               }));
-        throws(/* None */0, (function (param) {
+        throws(undefined, (function (param) {
                 return Aeson_decode.nullable(Aeson_decode.$$int, param);
               }), /* :: */[
               /* Bool */6,
@@ -272,7 +272,7 @@ describe("nullable", (function () {
                 ]
               ]
             ]);
-        return throws(/* None */0, (function (param) {
+        return throws(undefined, (function (param) {
                       return Aeson_decode.nullable(Aeson_decode.bool, param);
                     }), /* :: */[
                     /* Int */1,
@@ -288,12 +288,12 @@ describe("nullAs", (function () {
                 return Jest.Expect[/* toEqual */12](null, Jest.Expect[/* expect */0](Aeson_decode.nullAs(null, null)));
               }));
         Jest.test("as None", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.nullAs(/* None */0, null)));
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.nullAs(undefined, null)));
               }));
         Jest.test("as Some _", (function () {
-                return Jest.Expect[/* toEqual */12](/* Some */["foo"], Jest.Expect[/* expect */0](Aeson_decode.nullAs(/* Some */["foo"], null)));
+                return Jest.Expect[/* toEqual */12]("foo", Jest.Expect[/* expect */0](Aeson_decode.nullAs("foo", null)));
               }));
-        return throws(/* None */0, (function (param) {
+        return throws(undefined, (function (param) {
                       return Aeson_decode.nullAs(0, param);
                     }), /* :: */[
                     /* Bool */6,
@@ -363,7 +363,7 @@ describe("array", (function () {
                                   return Aeson_decode.array(Aeson_decode.bool, param);
                                 }), JSON.parse(" [1, 2, 3] ")));
               }));
-        return throws(/* None */0, (function (param) {
+        return throws(undefined, (function (param) {
                       return Aeson_decode.array(Aeson_decode.$$int, param);
                     }), /* :: */[
                     /* Bool */6,
@@ -458,7 +458,7 @@ describe("list", (function () {
                                   return Aeson_decode.list(Aeson_decode.bool, param);
                                 }), JSON.parse(" [1, 2, 3] ")));
               }));
-        return throws(/* None */0, (function (param) {
+        return throws(undefined, (function (param) {
                       return Aeson_decode.list(Aeson_decode.$$int, param);
                     }), /* :: */[
                     /* Bool */6,
@@ -564,7 +564,7 @@ describe("dict", (function () {
                                   return Aeson_decode.dict(Aeson_decode.string, param);
                                 }), JSON.parse(" { \"a\": null, \"b\": null } ")));
               }));
-        return throws(/* None */0, (function (param) {
+        return throws(undefined, (function (param) {
                       return Aeson_decode.dict(Aeson_decode.$$int, param);
                     }), /* :: */[
                     /* Bool */6,
@@ -611,7 +611,7 @@ describe("field", (function () {
                                   return Aeson_decode.field("b", Aeson_decode.string, param);
                                 }), JSON.parse(" { \"a\": null, \"b\": null } ")));
               }));
-        return throws(/* None */0, (function (param) {
+        return throws(undefined, (function (param) {
                       return Aeson_decode.field("foo", Aeson_decode.$$int, param);
                     }), /* :: */[
                     /* Bool */6,
@@ -662,7 +662,7 @@ describe("at", (function () {
                                         return Aeson_decode.nullAs(partial_arg, param);
                                       }))(JSON.parse(" {\n        \"a\": { \"x\" : null }, \n        \"b\": null \n      } "))));
               }));
-        return throws(/* None */0, Aeson_decode.at(/* :: */[
+        return throws(undefined, Aeson_decode.at(/* :: */[
                         "foo",
                         /* :: */[
                           "bar",
@@ -694,78 +694,78 @@ describe("at", (function () {
 
 describe("optional", (function () {
         Jest.test("bool -> int", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, true)));
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, true)));
               }));
         Jest.test("float -> int", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, 1.23)));
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, 1.23)));
               }));
         Jest.test("int -> int", (function () {
-                return Jest.Expect[/* toEqual */12](/* Some */[23], Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, 23)));
+                return Jest.Expect[/* toEqual */12](23, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, 23)));
               }));
         Jest.test("int32 -> int32", (function () {
-                return Jest.Expect[/* toEqual */12](/* Some */[23], Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.int32, 23)));
+                return Jest.Expect[/* toEqual */12](23, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.int32, 23)));
               }));
         Jest.test("int64 -> int64", (function () {
-                return Jest.Expect[/* toEqual */12](/* Some */[/* int64 */[
-                              /* hi */0,
-                              /* lo */64
-                            ]], Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.int64_of_array, /* int64 */[
+                return Jest.Expect[/* toEqual */12](/* int64 */[
+                            /* hi */0,
+                            /* lo */64
+                          ], Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.int64_of_array, /* int64 */[
                                     /* hi */0,
                                     /* lo */64
                                   ])));
               }));
         Jest.test("string -> int", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, "test")));
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, "test")));
               }));
         Jest.test("null -> int", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, null)));
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, null)));
               }));
         Jest.test("array -> int", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, /* array */[])));
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, /* array */[])));
               }));
         Jest.test("object -> int", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, Aeson_encode.object_(/* [] */0))));
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$int, Aeson_encode.object_(/* [] */0))));
               }));
         Jest.test("bool -> bool ", (function () {
-                return Jest.Expect[/* toEqual */12](/* Some */[true], Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.bool, true)));
+                return Jest.Expect[/* toEqual */12](true, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.bool, true)));
               }));
         Jest.test("float -> float", (function () {
-                return Jest.Expect[/* toEqual */12](/* Some */[1.23], Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$float, 1.23)));
+                return Jest.Expect[/* toEqual */12](1.23, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.$$float, 1.23)));
               }));
         Jest.test("string -> string", (function () {
-                return Jest.Expect[/* toEqual */12](/* Some */["test"], Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.string, "test")));
+                return Jest.Expect[/* toEqual */12]("test", Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.string, "test")));
               }));
         Jest.test("null -> null", (function () {
                 var partial_arg = null;
-                return Jest.Expect[/* toEqual */12](/* Some */[null], Jest.Expect[/* expect */0](Aeson_decode.optional((function (param) {
+                return Jest.Expect[/* toEqual */12](null, Jest.Expect[/* expect */0](Aeson_decode.optional((function (param) {
                                       return Aeson_decode.nullAs(partial_arg, param);
                                     }), null)));
               }));
         Jest.test("int -> bool", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.bool, 1)));
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.optional(Aeson_decode.bool, 1)));
               }));
         Jest.test("optional field", (function () {
-                return Jest.Expect[/* toEqual */12](/* Some */[2], Jest.Expect[/* expect */0](Aeson_decode.optional((function (param) {
+                return Jest.Expect[/* toEqual */12](2, Jest.Expect[/* expect */0](Aeson_decode.optional((function (param) {
                                       return Aeson_decode.field("x", Aeson_decode.$$int, param);
                                     }), JSON.parse(" { \"x\": 2} "))));
               }));
         Jest.test("optional field - incorrect type", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.optional((function (param) {
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.optional((function (param) {
                                       return Aeson_decode.field("x", Aeson_decode.$$int, param);
                                     }), JSON.parse(" { \"x\": 2.3} "))));
               }));
         Jest.test("optional field - no such field", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.optional((function (param) {
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.optional((function (param) {
                                       return Aeson_decode.field("y", Aeson_decode.$$int, param);
                                     }), JSON.parse(" { \"x\": 2} "))));
               }));
         Jest.test("field optional", (function () {
-                return Jest.Expect[/* toEqual */12](/* Some */[2], Jest.Expect[/* expect */0](Aeson_decode.field("x", (function (param) {
+                return Jest.Expect[/* toEqual */12](2, Jest.Expect[/* expect */0](Aeson_decode.field("x", (function (param) {
                                       return Aeson_decode.optional(Aeson_decode.$$int, param);
                                     }), JSON.parse(" { \"x\": 2} "))));
               }));
         Jest.test("field optional - incorrect type", (function () {
-                return Jest.Expect[/* toEqual */12](/* None */0, Jest.Expect[/* expect */0](Aeson_decode.field("x", (function (param) {
+                return Jest.Expect[/* toEqual */12](undefined, Jest.Expect[/* expect */0](Aeson_decode.field("x", (function (param) {
                                       return Aeson_decode.optional(Aeson_decode.$$int, param);
                                     }), JSON.parse(" { \"x\": 2.3} "))));
               }));
@@ -811,7 +811,7 @@ describe("oneOf", (function () {
           Aeson_decode.$$int,
           partial_arg_001
         ];
-        return throws(/* None */0, (function (param) {
+        return throws(undefined, (function (param) {
                       return Aeson_decode.oneOf(partial_arg, param);
                     }), /* :: */[
                     /* Bool */6,
@@ -863,7 +863,7 @@ describe("tryEither", (function () {
                                         return Aeson_decode.field("x", Aeson_decode.$$int, param);
                                       }))(23)));
               }));
-        return throws(/* None */0, Aeson_decode.tryEither(Aeson_decode.$$int, (function (param) {
+        return throws(undefined, Aeson_decode.tryEither(Aeson_decode.$$int, (function (param) {
                           return Aeson_decode.field("x", Aeson_decode.$$int, param);
                         })), /* :: */[
                     /* Bool */6,
@@ -916,7 +916,7 @@ describe("map", (function () {
                                       return 2 + param | 0;
                                     }), Aeson_decode.$$int, 23)));
               }));
-        return throws(/* None */0, (function (param) {
+        return throws(undefined, (function (param) {
                       return Aeson_decode.map((function (param) {
                                     return 2 + param | 0;
                                   }), Aeson_decode.$$int, param);
@@ -957,7 +957,7 @@ describe("andThen", (function () {
                                       return Aeson_decode.$$int;
                                     }), Aeson_decode.$$float, 23)));
               }));
-        throws(/* Some */["int andThen int "], (function (param) {
+        throws("int andThen int ", (function (param) {
                 return Aeson_decode.andThen((function () {
                               return Aeson_decode.$$int;
                             }), Aeson_decode.$$int, param);
@@ -980,7 +980,7 @@ describe("andThen", (function () {
                 ]
               ]
             ]);
-        throws(/* Some */["float andThen int "], (function (param) {
+        throws("float andThen int ", (function (param) {
                 return Aeson_decode.andThen((function () {
                               return Aeson_decode.$$int;
                             }), Aeson_decode.$$float, param);
@@ -988,7 +988,7 @@ describe("andThen", (function () {
               /* Float */0,
               /* [] */0
             ]);
-        return throws(/* Some */["int to "], (function (param) {
+        return throws("int to ", (function (param) {
                       return Aeson_decode.andThen((function () {
                                     return Aeson_decode.$$float;
                                   }), Aeson_decode.$$int, param);

--- a/lib/js/examples/encode.js
+++ b/lib/js/examples/encode.js
@@ -59,7 +59,7 @@ function line(r) {
                 /* :: */[
                   /* tuple */[
                     "thickness",
-                    match ? match[0] : null
+                    match !== undefined ? match : null
                   ],
                   /* [] */0
                 ]
@@ -81,7 +81,7 @@ var data = /* record */[
     /* x */5.3,
     /* y */3.8
   ],
-  /* thickness : Some */[2]
+  /* thickness */2
 ];
 
 console.log(line(data));

--- a/lib/js/src/Aeson_compatibility.js
+++ b/lib/js/src/Aeson_compatibility.js
@@ -3,6 +3,7 @@
 var Block = require("bs-platform/lib/js/block.js");
 var Curry = require("bs-platform/lib/js/curry.js");
 var Js_exn = require("bs-platform/lib/js/js_exn.js");
+var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
 
 function left(a) {
   return /* Left */Block.__(0, [a]);
@@ -115,15 +116,15 @@ function error(v) {
 
 function hush(v) {
   return either((function () {
-                return /* None */0;
+                return undefined;
               }), (function (v$prime) {
-                return /* Some */[v$prime];
+                return Js_primitive.some(v$prime);
               }), v);
 }
 
 function note(e, param) {
-  if (param) {
-    return /* Right */Block.__(1, [param[0]]);
+  if (param !== undefined) {
+    return /* Right */Block.__(1, [Js_primitive.valFromOption(param)]);
   } else {
     return /* Left */Block.__(0, [e]);
   }

--- a/lib/js/src/Aeson_decode.js
+++ b/lib/js/src/Aeson_decode.js
@@ -9,6 +9,7 @@ var Js_json = require("bs-platform/lib/js/js_json.js");
 var Caml_array = require("bs-platform/lib/js/caml_array.js");
 var Caml_int64 = require("bs-platform/lib/js/caml_int64.js");
 var Caml_format = require("bs-platform/lib/js/caml_format.js");
+var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
 var Caml_exceptions = require("bs-platform/lib/js/caml_exceptions.js");
 var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exceptions.js");
 
@@ -359,21 +360,21 @@ function optional(decode, json) {
   catch (raw_exn){
     var exn = Js_exn.internalToOCamlException(raw_exn);
     if (exn[0] === DecodeError) {
-      return /* None */0;
+      return undefined;
     } else {
       throw exn;
     }
   }
   if (exit === 1) {
-    return /* Some */[v];
+    return Js_primitive.some(v);
   }
   
 }
 
 function result(decodeA, decodeB, json) {
   var match = Js_json.decodeObject(json);
-  if (match) {
-    var o = match[0];
+  if (match !== undefined) {
+    var o = Js_primitive.valFromOption(match);
     var match$1 = o["Ok"];
     if (match$1 !== undefined) {
       return /* Ok */Block.__(0, [Curry._1(decodeA, match$1)]);
@@ -398,8 +399,8 @@ function result(decodeA, decodeB, json) {
 
 function either(decodeL, decodeR, json) {
   var match = Js_json.decodeObject(json);
-  if (match) {
-    var o = match[0];
+  if (match !== undefined) {
+    var o = Js_primitive.valFromOption(match);
     var match$1 = o["Left"];
     if (match$1 !== undefined) {
       return /* Left */Block.__(0, [Curry._1(decodeL, match$1)]);

--- a/lib/js/src/Aeson_encode.js
+++ b/lib/js/src/Aeson_encode.js
@@ -4,26 +4,27 @@ var List = require("bs-platform/lib/js/list.js");
 var $$Array = require("bs-platform/lib/js/array.js");
 var Curry = require("bs-platform/lib/js/curry.js");
 var Js_dict = require("bs-platform/lib/js/js_dict.js");
+var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
 
 function nullable(encode, param) {
-  if (param) {
-    return Curry._1(encode, param[0]);
+  if (param !== undefined) {
+    return Curry._1(encode, Js_primitive.valFromOption(param));
   } else {
     return null;
   }
 }
 
 function withDefault(d, encode, param) {
-  if (param) {
-    return Curry._1(encode, param[0]);
+  if (param !== undefined) {
+    return Curry._1(encode, Js_primitive.valFromOption(param));
   } else {
     return d;
   }
 }
 
 function optional(encode, optionalValue) {
-  if (optionalValue) {
-    return Curry._1(encode, optionalValue[0]);
+  if (optionalValue !== undefined) {
+    return Curry._1(encode, Js_primitive.valFromOption(optionalValue));
   } else {
     return null;
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/plow-technologies/bs-aeson#readme",
   "devDependencies": {
-    "bs-platform": "^3.1.0",
-    "@glennsl/bs-jest": "^0.4.2"
+    "@glennsl/bs-jest": "^0.4.2",
+    "bs-platform": "^4.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,9 +400,9 @@ browser-resolve@^1.11.2:
   dependencies:
     resolve "1.1.7"
 
-bs-platform@^3.1.0:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.5.tgz#fb34ee4702bc9163848d5537096c4f31ebaeed40"
+bs-platform@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.1.tgz#544b58c2a53299cf406b57477e06389e4adab421"
 
 bser@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Upgraded to bs-platform 4.0.1.  

There is only one difference which I noticed, the first example returns an `undefined` in the final position instead of zero.