### PR TITLE
Remove nativeint, upgrade bs-zarith, and bs-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Then add `bs-aeson` to `bs-dependencies` in your `bsconfig.json`:
 
 ## Changes
 
+### 4.7.0
+
+* BREAKING CHANGE: Remove 'nativeint' since Rescript no longer supports this
+
 ### 4.6.0
 
 * Add `Aeson.Decode.beltMap`, `Aeson.Decode.beltMapInt`, `Aeson.Decode.beltMapString`.

--- a/lib/js/__tests__/Aeson_compatibility_test.js
+++ b/lib/js/__tests__/Aeson_compatibility_test.js
@@ -31,15 +31,15 @@ Jest.describe("Either.t", (function (param) {
                                     _0: 123
                                   })));
               }));
-        return Jest.test("of_result: Ok", (function (param) {
-                      return Jest.Expect.toEqual({
-                                  TAG: /* Right */1,
-                                  _0: "Goodbye"
-                                }, Jest.Expect.expect(Aeson_compatibility.Either.of_result({
-                                          TAG: /* Ok */0,
-                                          _0: "Goodbye"
-                                        })));
-                    }));
+        Jest.test("of_result: Ok", (function (param) {
+                return Jest.Expect.toEqual({
+                            TAG: /* Right */1,
+                            _0: "Goodbye"
+                          }, Jest.Expect.expect(Aeson_compatibility.Either.of_result({
+                                    TAG: /* Ok */0,
+                                    _0: "Goodbye"
+                                  })));
+              }));
       }));
 
 /*  Not a pure module */

--- a/lib/js/__tests__/Aeson_decode_test.js
+++ b/lib/js/__tests__/Aeson_decode_test.js
@@ -3,15 +3,15 @@
 var U = require("bs-zarith/lib/js/src/U.js");
 var Jest = require("@glennsl/bs-jest/lib/js/src/jest.js");
 var Bigint = require("bs-zarith/lib/js/src/Bigint.js");
-var Belt_Id = require("bs-platform/lib/js/belt_Id.js");
-var Belt_Map = require("bs-platform/lib/js/belt_Map.js");
-var Caml_obj = require("bs-platform/lib/js/caml_obj.js");
-var Caml_int64 = require("bs-platform/lib/js/caml_int64.js");
-var Belt_MapInt = require("bs-platform/lib/js/belt_MapInt.js");
-var Caml_format = require("bs-platform/lib/js/caml_format.js");
+var Belt_Id = require("rescript/lib/js/belt_Id.js");
+var Belt_Map = require("rescript/lib/js/belt_Map.js");
+var Caml_obj = require("rescript/lib/js/caml_obj.js");
+var Caml_int64 = require("rescript/lib/js/caml_int64.js");
+var Belt_MapInt = require("rescript/lib/js/belt_MapInt.js");
+var Caml_format = require("rescript/lib/js/caml_format.js");
 var Aeson_decode = require("../src/Aeson_decode.js");
 var Aeson_encode = require("../src/Aeson_encode.js");
-var Belt_MapString = require("bs-platform/lib/js/belt_MapString.js");
+var Belt_MapString = require("rescript/lib/js/belt_MapString.js");
 
 function test(decoder, prefix, param) {
   switch (param) {
@@ -74,7 +74,7 @@ function decodeOnpingKey(json) {
         };
 }
 
-var cmp = Caml_obj.caml_compare;
+var cmp = Caml_obj.compare;
 
 var OnpingKeyComparable = Belt_Id.MakeComparable({
       cmp: cmp
@@ -87,7 +87,7 @@ function decodePid(json) {
         };
 }
 
-var cmp$1 = Caml_obj.caml_compare;
+var cmp$1 = Caml_obj.compare;
 
 var PidComparable = Belt_Id.MakeComparable({
       cmp: cmp$1
@@ -100,25 +100,25 @@ Jest.describe("bool", (function (param) {
         Jest.test("bool - false", (function (param) {
                 return Jest.Expect.toEqual(false, Jest.Expect.expect(Aeson_decode.bool(false)));
               }));
-        return throws(undefined, Aeson_decode.bool, {
-                    hd: /* Float */0,
+        throws(undefined, Aeson_decode.bool, {
+              hd: /* Float */0,
+              tl: {
+                hd: /* Int */1,
+                tl: {
+                  hd: /* String */2,
+                  tl: {
+                    hd: /* Null */3,
                     tl: {
-                      hd: /* Int */1,
+                      hd: /* Array */4,
                       tl: {
-                        hd: /* String */2,
-                        tl: {
-                          hd: /* Null */3,
-                          tl: {
-                            hd: /* Array */4,
-                            tl: {
-                              hd: /* Object */5,
-                              tl: /* [] */0
-                            }
-                          }
-                        }
+                        hd: /* Object */5,
+                        tl: /* [] */0
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("float", (function (param) {
@@ -128,22 +128,22 @@ Jest.describe("float", (function (param) {
         Jest.test("int", (function (param) {
                 return Jest.Expect.toEqual(23, Jest.Expect.expect(Aeson_decode.$$float(23)));
               }));
-        return throws(undefined, Aeson_decode.$$float, {
-                    hd: /* Bool */6,
+        throws(undefined, Aeson_decode.$$float, {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* String */2,
+                tl: {
+                  hd: /* Null */3,
+                  tl: {
+                    hd: /* Array */4,
                     tl: {
-                      hd: /* String */2,
-                      tl: {
-                        hd: /* Null */3,
-                        tl: {
-                          hd: /* Array */4,
-                          tl: {
-                            hd: /* Object */5,
-                            tl: /* [] */0
-                          }
-                        }
-                      }
+                      hd: /* Object */5,
+                      tl: /* [] */0
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("int", (function (param) {
@@ -154,112 +154,136 @@ Jest.describe("int", (function (param) {
                 var big_int = 2147483648;
                 return Jest.Expect.toEqual(big_int, Jest.Expect.expect(Aeson_decode.$$int(big_int)));
               }));
-        return throws(undefined, Aeson_decode.$$int, {
-                    hd: /* Bool */6,
+        throws(undefined, Aeson_decode.$$int, {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* String */2,
+                  tl: {
+                    hd: /* Null */3,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Array */4,
                       tl: {
-                        hd: /* String */2,
-                        tl: {
-                          hd: /* Null */3,
-                          tl: {
-                            hd: /* Array */4,
-                            tl: {
-                              hd: /* Object */5,
-                              tl: /* [] */0
-                            }
-                          }
-                        }
+                        hd: /* Object */5,
+                        tl: /* [] */0
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("int32", (function (param) {
         Jest.test("int32", (function (param) {
                 return Jest.Expect.toEqual(23, Jest.Expect.expect(Aeson_decode.int32(23)));
               }));
-        return Jest.test("int32", (function (param) {
-                      return Jest.Expect.toEqual(-23223, Jest.Expect.expect(Aeson_decode.int32(-23223)));
-                    }));
+        Jest.test("int32", (function (param) {
+                return Jest.Expect.toEqual(-23223, Jest.Expect.expect(Aeson_decode.int32(-23223)));
+              }));
       }));
 
 Jest.describe("int64", (function (param) {
         Jest.test("int64", (function (param) {
-                return Jest.Expect.toEqual(Caml_int64.mk(23, 0), Jest.Expect.expect(Aeson_decode.int64("23")));
+                return Jest.Expect.toEqual([
+                            0,
+                            23
+                          ], Jest.Expect.expect(Aeson_decode.int64("23")));
               }));
         Jest.test("int64", (function (param) {
-                return Jest.Expect.toEqual(Caml_int64.mk(23, 0), Jest.Expect.expect(Aeson_decode.int64(23)));
+                return Jest.Expect.toEqual([
+                            0,
+                            23
+                          ], Jest.Expect.expect(Aeson_decode.int64(23)));
               }));
-        return Jest.test("int64", (function (param) {
-                      return Jest.Expect.toEqual([
-                                  0,
-                                  23
-                                ], Jest.Expect.expect(Aeson_decode.int64(23)));
-                    }));
+        Jest.test("int64", (function (param) {
+                return Jest.Expect.toEqual([
+                            0,
+                            23
+                          ], Jest.Expect.expect(Aeson_decode.int64(23)));
+              }));
       }));
 
 Jest.describe("int64_of_array", (function (param) {
         Jest.test("int64_of_array", (function (param) {
-                return Jest.Expect.toEqual(Caml_int64.mk(23, 0), Jest.Expect.expect(Aeson_decode.int64_of_array(Caml_int64.mk(23, 0))));
+                return Jest.Expect.toEqual([
+                            0,
+                            23
+                          ], Jest.Expect.expect(Aeson_decode.int64_of_array([
+                                    0,
+                                    23
+                                  ])));
               }));
         Jest.test("int64_of_array", (function (param) {
-                return Jest.Expect.toEqual(Caml_format.caml_int64_of_string("9223372036854775807"), Jest.Expect.expect(Aeson_decode.int64_of_array(Caml_format.caml_int64_of_string("9223372036854775807"))));
+                return Jest.Expect.toEqual(Caml_format.int64_of_string("9223372036854775807"), Jest.Expect.expect(Aeson_decode.int64_of_array(Caml_format.int64_of_string("9223372036854775807"))));
               }));
-        return Jest.test("int64_of_array", (function (param) {
-                      return Jest.Expect.toEqual(Caml_format.caml_int64_of_string("-9223372036854775807"), Jest.Expect.expect(Aeson_decode.int64_of_array(Caml_format.caml_int64_of_string("-9223372036854775807"))));
-                    }));
+        Jest.test("int64_of_array", (function (param) {
+                return Jest.Expect.toEqual(Caml_format.int64_of_string("-9223372036854775807"), Jest.Expect.expect(Aeson_decode.int64_of_array(Caml_format.int64_of_string("-9223372036854775807"))));
+              }));
       }));
 
 Jest.describe("int64_of_string", (function (param) {
         Jest.test("23", (function (param) {
-                return Jest.Expect.toEqual(Caml_int64.mk(23, 0), Jest.Expect.expect(Aeson_decode.int64_of_string(Aeson_encode.int64_to_string(Caml_int64.mk(23, 0)))));
+                return Jest.Expect.toEqual([
+                            0,
+                            23
+                          ], Jest.Expect.expect(Aeson_decode.int64_of_string(Aeson_encode.int64_to_string([
+                                        0,
+                                        23
+                                      ]))));
               }));
         Jest.test("-1000", (function (param) {
-                return Jest.Expect.toEqual(Caml_int64.mk(-1000, -1), Jest.Expect.expect(Aeson_decode.int64_of_string(Aeson_encode.int64_to_string(Caml_int64.mk(-1000, -1)))));
+                return Jest.Expect.toEqual([
+                            -1,
+                            4294966296
+                          ], Jest.Expect.expect(Aeson_decode.int64_of_string(Aeson_encode.int64_to_string([
+                                        -1,
+                                        4294966296
+                                      ]))));
               }));
         Jest.test("-1", (function (param) {
                 return Jest.Expect.toEqual(Caml_int64.neg_one, Jest.Expect.expect(Aeson_decode.int64_of_string(Aeson_encode.int64_to_string(Caml_int64.neg_one))));
               }));
-        return Jest.test("23", (function (param) {
-                      return Jest.Expect.toEqual(Caml_format.caml_int64_of_string("999999999999"), Jest.Expect.expect(Aeson_decode.int64_of_string(Aeson_encode.int64_to_string(Caml_format.caml_int64_of_string("999999999999")))));
-                    }));
+        Jest.test("23", (function (param) {
+                return Jest.Expect.toEqual(Caml_format.int64_of_string("999999999999"), Jest.Expect.expect(Aeson_decode.int64_of_string(Aeson_encode.int64_to_string(Caml_format.int64_of_string("999999999999")))));
+              }));
       }));
 
 Jest.describe("uint8", (function (param) {
         Jest.test("uint8", (function (param) {
                 return Jest.Expect.toEqual(U.UInt8.ofInt(23), Jest.Expect.expect(Aeson_decode.uint8(Aeson_encode.uint8(U.UInt8.ofInt(23)))));
               }));
-        return Jest.test("uint8", (function (param) {
-                      return Jest.Expect.toEqual(U.UInt8.ofInt(255), Jest.Expect.expect(Aeson_decode.uint8(Aeson_encode.uint8(U.UInt8.ofInt(255)))));
-                    }));
+        Jest.test("uint8", (function (param) {
+                return Jest.Expect.toEqual(U.UInt8.ofInt(255), Jest.Expect.expect(Aeson_decode.uint8(Aeson_encode.uint8(U.UInt8.ofInt(255)))));
+              }));
       }));
 
 Jest.describe("uint16", (function (param) {
         Jest.test("uint16", (function (param) {
                 return Jest.Expect.toEqual(U.UInt16.ofInt(23), Jest.Expect.expect(Aeson_decode.uint16(Aeson_encode.uint16(U.UInt16.ofInt(23)))));
               }));
-        return Jest.test("uint16", (function (param) {
-                      return Jest.Expect.toEqual(U.UInt16.ofInt(1233), Jest.Expect.expect(Aeson_decode.uint16(Aeson_encode.uint16(U.UInt16.ofInt(1233)))));
-                    }));
+        Jest.test("uint16", (function (param) {
+                return Jest.Expect.toEqual(U.UInt16.ofInt(1233), Jest.Expect.expect(Aeson_decode.uint16(Aeson_encode.uint16(U.UInt16.ofInt(1233)))));
+              }));
       }));
 
 Jest.describe("uint32", (function (param) {
         Jest.test("uint32", (function (param) {
                 return Jest.Expect.toEqual(U.UInt32.ofInt(23), Jest.Expect.expect(Aeson_decode.uint32(Aeson_encode.uint32(U.UInt32.ofInt(23)))));
               }));
-        return Jest.test("uint32", (function (param) {
-                      return Jest.Expect.toEqual(U.UInt32.ofInt(23223), Jest.Expect.expect(Aeson_decode.uint32(Aeson_encode.uint32(U.UInt32.ofInt(23223)))));
-                    }));
+        Jest.test("uint32", (function (param) {
+                return Jest.Expect.toEqual(U.UInt32.ofInt(23223), Jest.Expect.expect(Aeson_decode.uint32(Aeson_encode.uint32(U.UInt32.ofInt(23223)))));
+              }));
       }));
 
 Jest.describe("uint64", (function (param) {
         Jest.test("uint64", (function (param) {
                 return Jest.Expect.toEqual(U.UInt64.ofInt(23), Jest.Expect.expect(Aeson_decode.uint64(Aeson_encode.uint64(U.UInt64.ofInt(23)))));
               }));
-        return Jest.test("uint64", (function (param) {
-                      return Jest.Expect.toEqual(U.UInt64.ofInt(26423), Jest.Expect.expect(Aeson_decode.uint64(Aeson_encode.uint64(U.UInt64.ofInt(26423)))));
-                    }));
+        Jest.test("uint64", (function (param) {
+                return Jest.Expect.toEqual(U.UInt64.ofInt(26423), Jest.Expect.expect(Aeson_decode.uint64(Aeson_encode.uint64(U.UInt64.ofInt(26423)))));
+              }));
       }));
 
 Jest.describe("bigint", (function (param) {
@@ -269,41 +293,41 @@ Jest.describe("bigint", (function (param) {
         Jest.test("26423", (function (param) {
                 return Jest.Expect.toEqual(Bigint.of_int(26423), Jest.Expect.expect(Aeson_decode.bigint(Aeson_encode.bigint(Bigint.of_int(26423)))));
               }));
-        return Jest.test("-1289848928492483456726423", (function (param) {
-                      return Jest.Expect.toEqual(Bigint.of_string("-1289848928492483456726423"), Jest.Expect.expect(Aeson_decode.bigint(Aeson_encode.bigint(Bigint.of_string("-1289848928492483456726423")))));
-                    }));
+        Jest.test("-1289848928492483456726423", (function (param) {
+                return Jest.Expect.toEqual(Bigint.of_string("-1289848928492483456726423"), Jest.Expect.expect(Aeson_decode.bigint(Aeson_encode.bigint(Bigint.of_string("-1289848928492483456726423")))));
+              }));
       }));
 
 Jest.describe("string", (function (param) {
         Jest.test("string", (function (param) {
                 return Jest.Expect.toEqual("test", Jest.Expect.expect(Aeson_decode.string("test")));
               }));
-        return throws(undefined, Aeson_decode.string, {
-                    hd: /* Bool */6,
+        throws(undefined, Aeson_decode.string, {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* Int */1,
+                  tl: {
+                    hd: /* Null */3,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Array */4,
                       tl: {
-                        hd: /* Int */1,
-                        tl: {
-                          hd: /* Null */3,
-                          tl: {
-                            hd: /* Array */4,
-                            tl: {
-                              hd: /* Object */5,
-                              tl: /* [] */0
-                            }
-                          }
-                        }
+                        hd: /* Object */5,
+                        tl: /* [] */0
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("date", (function (param) {
         var now = new Date("2017-12-08T06:03:22Z");
-        return Jest.test("date", (function (param) {
-                      return Jest.Expect.toEqual(now, Jest.Expect.expect(Aeson_decode.date(Aeson_encode.date(now))));
-                    }));
+        Jest.test("date", (function (param) {
+                return Jest.Expect.toEqual(now, Jest.Expect.expect(Aeson_decode.date(Aeson_encode.date(now))));
+              }));
       }));
 
 Jest.describe("nullable", (function (param) {
@@ -346,12 +370,12 @@ Jest.describe("nullable", (function (param) {
                 }
               }
             });
-        return throws(undefined, (function (param) {
-                      return Aeson_decode.nullable(Aeson_decode.bool, param);
-                    }), {
-                    hd: /* Int */1,
-                    tl: /* [] */0
-                  });
+        throws(undefined, (function (param) {
+                return Aeson_decode.nullable(Aeson_decode.bool, param);
+              }), {
+              hd: /* Int */1,
+              tl: /* [] */0
+            });
       }));
 
 Jest.describe("nullAs", (function (param) {
@@ -367,27 +391,27 @@ Jest.describe("nullAs", (function (param) {
         Jest.test("as Some _", (function (param) {
                 return Jest.Expect.toEqual("foo", Jest.Expect.expect(Aeson_decode.nullAs("foo", null)));
               }));
-        return throws(undefined, (function (param) {
-                      return Aeson_decode.nullAs(0, param);
-                    }), {
-                    hd: /* Bool */6,
+        throws(undefined, (function (param) {
+                return Aeson_decode.nullAs(0, param);
+              }), {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* Int */1,
+                  tl: {
+                    hd: /* String */2,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Array */4,
                       tl: {
-                        hd: /* Int */1,
-                        tl: {
-                          hd: /* String */2,
-                          tl: {
-                            hd: /* Array */4,
-                            tl: {
-                              hd: /* Object */5,
-                              tl: /* [] */0
-                            }
-                          }
-                        }
+                        hd: /* Object */5,
+                        tl: /* [] */0
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("array", (function (param) {
@@ -437,27 +461,27 @@ Jest.describe("array", (function (param) {
                                   return Aeson_decode.array(Aeson_decode.bool, param);
                                 }), JSON.parse(" [1, 2, 3] ")));
               }));
-        return throws(undefined, (function (param) {
-                      return Aeson_decode.array(Aeson_decode.$$int, param);
-                    }), {
-                    hd: /* Bool */6,
+        throws(undefined, (function (param) {
+                return Aeson_decode.array(Aeson_decode.$$int, param);
+              }), {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* Int */1,
+                  tl: {
+                    hd: /* String */2,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Null */3,
                       tl: {
-                        hd: /* Int */1,
-                        tl: {
-                          hd: /* String */2,
-                          tl: {
-                            hd: /* Null */3,
-                            tl: {
-                              hd: /* Object */5,
-                              tl: /* [] */0
-                            }
-                          }
-                        }
+                        hd: /* Object */5,
+                        tl: /* [] */0
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("list", (function (param) {
@@ -532,27 +556,27 @@ Jest.describe("list", (function (param) {
                                   return Aeson_decode.list(Aeson_decode.bool, param);
                                 }), JSON.parse(" [1, 2, 3] ")));
               }));
-        return throws(undefined, (function (param) {
-                      return Aeson_decode.list(Aeson_decode.$$int, param);
-                    }), {
-                    hd: /* Bool */6,
+        throws(undefined, (function (param) {
+                return Aeson_decode.list(Aeson_decode.$$int, param);
+              }), {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* Int */1,
+                  tl: {
+                    hd: /* String */2,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Null */3,
                       tl: {
-                        hd: /* Int */1,
-                        tl: {
-                          hd: /* String */2,
-                          tl: {
-                            hd: /* Null */3,
-                            tl: {
-                              hd: /* Object */5,
-                              tl: /* [] */0
-                            }
-                          }
-                        }
+                        hd: /* Object */5,
+                        tl: /* [] */0
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("pair", (function (param) {
@@ -583,193 +607,193 @@ Jest.describe("pair", (function (param) {
                                   return Aeson_decode.pair(Aeson_decode.$$int, Aeson_decode.$$int, param);
                                 }), JSON.parse(" [\"3\", 4] ")));
               }));
-        return Jest.test("pair bad right type", (function (param) {
-                      return Jest.Expect.toThrow(Jest.Expect.expectFn((function (param) {
-                                        return Aeson_decode.pair(Aeson_decode.string, Aeson_decode.string, param);
-                                      }), JSON.parse(" [\"3\", 4] ")));
-                    }));
+        Jest.test("pair bad right type", (function (param) {
+                return Jest.Expect.toThrow(Jest.Expect.expectFn((function (param) {
+                                  return Aeson_decode.pair(Aeson_decode.string, Aeson_decode.string, param);
+                                }), JSON.parse(" [\"3\", 4] ")));
+              }));
       }));
 
 Jest.describe("tuple3", (function (param) {
-        return Jest.test("tuple3 string int string", (function (param) {
-                      return Jest.Expect.toEqual([
-                                  "a",
-                                  3,
-                                  "b"
-                                ], Jest.Expect.expect(Aeson_decode.tuple3(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" [\"a\", 3, \"b\"] "))));
-                    }));
+        Jest.test("tuple3 string int string", (function (param) {
+                return Jest.Expect.toEqual([
+                            "a",
+                            3,
+                            "b"
+                          ], Jest.Expect.expect(Aeson_decode.tuple3(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" [\"a\", 3, \"b\"] "))));
+              }));
       }));
 
 Jest.describe("tuple4", (function (param) {
-        return Jest.test("tuple4 string int string bool", (function (param) {
-                      return Jest.Expect.toEqual([
-                                  "a",
-                                  3,
-                                  "b",
-                                  true
-                                ], Jest.Expect.expect(Aeson_decode.tuple4(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, JSON.parse(" [\"a\", 3, \"b\", true] "))));
-                    }));
+        Jest.test("tuple4 string int string bool", (function (param) {
+                return Jest.Expect.toEqual([
+                            "a",
+                            3,
+                            "b",
+                            true
+                          ], Jest.Expect.expect(Aeson_decode.tuple4(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, JSON.parse(" [\"a\", 3, \"b\", true] "))));
+              }));
       }));
 
 Jest.describe("tuple5", (function (param) {
-        return Jest.test("tuple5 string int string bool int", (function (param) {
-                      return Jest.Expect.toEqual([
-                                  "a",
-                                  3,
-                                  "b",
-                                  true,
-                                  98
-                                ], Jest.Expect.expect(Aeson_decode.tuple5(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, JSON.parse(" [\"a\", 3, \"b\", true, 98] "))));
-                    }));
+        Jest.test("tuple5 string int string bool int", (function (param) {
+                return Jest.Expect.toEqual([
+                            "a",
+                            3,
+                            "b",
+                            true,
+                            98
+                          ], Jest.Expect.expect(Aeson_decode.tuple5(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, JSON.parse(" [\"a\", 3, \"b\", true, 98] "))));
+              }));
       }));
 
 Jest.describe("tuple6", (function (param) {
-        return Jest.test("tuple6 string int string bool int string", (function (param) {
-                      return Jest.Expect.toEqual([
-                                  "a",
-                                  3,
-                                  "b",
-                                  true,
-                                  98,
-                                  "sleepy"
-                                ], Jest.Expect.expect(Aeson_decode.tuple6(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" [\"a\", 3, \"b\", true, 98, \"sleepy\"] "))));
-                    }));
+        Jest.test("tuple6 string int string bool int string", (function (param) {
+                return Jest.Expect.toEqual([
+                            "a",
+                            3,
+                            "b",
+                            true,
+                            98,
+                            "sleepy"
+                          ], Jest.Expect.expect(Aeson_decode.tuple6(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" [\"a\", 3, \"b\", true, 98, \"sleepy\"] "))));
+              }));
       }));
 
 Jest.describe("tuple7", (function (param) {
-        return Jest.test("tuple7 string int string bool int string int", (function (param) {
-                      return Jest.Expect.toEqual([
-                                  "a",
-                                  3,
-                                  "b",
-                                  true,
-                                  98,
-                                  "sleepy",
-                                  100
-                                ], Jest.Expect.expect(Aeson_decode.tuple7(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.$$int, JSON.parse(" [\"a\", 3, \"b\", true, 98, \"sleepy\", 100] "))));
-                    }));
+        Jest.test("tuple7 string int string bool int string int", (function (param) {
+                return Jest.Expect.toEqual([
+                            "a",
+                            3,
+                            "b",
+                            true,
+                            98,
+                            "sleepy",
+                            100
+                          ], Jest.Expect.expect(Aeson_decode.tuple7(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.$$int, JSON.parse(" [\"a\", 3, \"b\", true, 98, \"sleepy\", 100] "))));
+              }));
       }));
 
 Jest.describe("tuple8", (function (param) {
-        return Jest.test("tuple8 string int string bool int string int string", (function (param) {
-                      return Jest.Expect.toEqual([
-                                  "a",
-                                  3,
-                                  "b",
-                                  true,
-                                  98,
-                                  "sleepy",
-                                  100,
-                                  "bedtime"
-                                ], Jest.Expect.expect(Aeson_decode.tuple8(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" [\"a\", 3, \"b\", true, 98, \"sleepy\", 100, \"bedtime\"] "))));
-                    }));
+        Jest.test("tuple8 string int string bool int string int string", (function (param) {
+                return Jest.Expect.toEqual([
+                            "a",
+                            3,
+                            "b",
+                            true,
+                            98,
+                            "sleepy",
+                            100,
+                            "bedtime"
+                          ], Jest.Expect.expect(Aeson_decode.tuple8(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" [\"a\", 3, \"b\", true, 98, \"sleepy\", 100, \"bedtime\"] "))));
+              }));
       }));
 
 Jest.describe("tuple9", (function (param) {
-        return Jest.test("tuple9 string int string bool int string int string bool", (function (param) {
-                      return Jest.Expect.toEqual([
-                                  "a",
-                                  3,
-                                  "b",
-                                  true,
-                                  98,
-                                  "sleepy",
-                                  100,
-                                  "bedtime",
-                                  false
-                                ], Jest.Expect.expect(Aeson_decode.tuple9(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, JSON.parse(" [\"a\", 3, \"b\", true, 98, \"sleepy\", 100, \"bedtime\", false] "))));
-                    }));
+        Jest.test("tuple9 string int string bool int string int string bool", (function (param) {
+                return Jest.Expect.toEqual([
+                            "a",
+                            3,
+                            "b",
+                            true,
+                            98,
+                            "sleepy",
+                            100,
+                            "bedtime",
+                            false
+                          ], Jest.Expect.expect(Aeson_decode.tuple9(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, JSON.parse(" [\"a\", 3, \"b\", true, 98, \"sleepy\", 100, \"bedtime\", false] "))));
+              }));
       }));
 
 Jest.describe("tuple10", (function (param) {
-        return Jest.test("tuple10 string int string bool int string int string bool int", (function (param) {
-                      return Jest.Expect.toEqual([
-                                  "a",
-                                  3,
-                                  "b",
-                                  true,
-                                  98,
-                                  "sleepy",
-                                  100,
-                                  "bedtime",
-                                  false,
-                                  22
-                                ], Jest.Expect.expect(Aeson_decode.tuple10(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, JSON.parse(" [\"a\", 3, \"b\", true, 98, \"sleepy\", 100, \"bedtime\", false, 22] "))));
-                    }));
+        Jest.test("tuple10 string int string bool int string int string bool int", (function (param) {
+                return Jest.Expect.toEqual([
+                            "a",
+                            3,
+                            "b",
+                            true,
+                            98,
+                            "sleepy",
+                            100,
+                            "bedtime",
+                            false,
+                            22
+                          ], Jest.Expect.expect(Aeson_decode.tuple10(Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.$$int, Aeson_decode.string, Aeson_decode.bool, Aeson_decode.$$int, JSON.parse(" [\"a\", 3, \"b\", true, 98, \"sleepy\", 100, \"bedtime\", false, 22] "))));
+              }));
       }));
 
 Jest.describe("singleEnumerator", (function (param) {
-        return Jest.test("singleEnumerator", (function (param) {
-                      return Jest.Expect.toEqual(/* SingleEnumerator */0, Jest.Expect.expect(Aeson_decode.singleEnumerator(/* SingleEnumerator */0, [])));
-                    }));
+        Jest.test("singleEnumerator", (function (param) {
+                return Jest.Expect.toEqual(/* SingleEnumerator */0, Jest.Expect.expect(Aeson_decode.singleEnumerator(/* SingleEnumerator */0, [])));
+              }));
       }));
 
 Jest.describe("string pid Belt.Map.t", (function (param) {
-        return Jest.test("test", (function (param) {
-                      return Jest.Expect.toEqual(Belt_Map.fromArray([
-                                      [
-                                        /* Pid */{
-                                          _0: 1
-                                        },
-                                        "A"
-                                      ],
-                                      [
-                                        /* Pid */{
-                                          _0: 2
-                                        },
-                                        "B"
-                                      ]
-                                    ], PidComparable), Jest.Expect.expect(Aeson_decode.beltMap(decodePid, Aeson_decode.string, PidComparable, JSON.parse(" [[1, \"A\"], [2, \"B\"]] "))));
-                    }));
+        Jest.test("test", (function (param) {
+                return Jest.Expect.toEqual(Belt_Map.fromArray([
+                                [
+                                  /* Pid */{
+                                    _0: 1
+                                  },
+                                  "A"
+                                ],
+                                [
+                                  /* Pid */{
+                                    _0: 2
+                                  },
+                                  "B"
+                                ]
+                              ], PidComparable), Jest.Expect.expect(Aeson_decode.beltMap(decodePid, Aeson_decode.string, PidComparable, JSON.parse(" [[1, \"A\"], [2, \"B\"]] "))));
+              }));
       }));
 
 Jest.describe("string onpingKey Belt.Map.t", (function (param) {
-        return Jest.test("test", (function (param) {
-                      return Jest.Expect.toEqual(Belt_Map.fromArray([
-                                      [
-                                        /* OnpingKey */{
-                                          _0: "a"
-                                        },
-                                        "A"
-                                      ],
-                                      [
-                                        /* OnpingKey */{
-                                          _0: "b"
-                                        },
-                                        "B"
-                                      ]
-                                    ], OnpingKeyComparable), Jest.Expect.expect(Aeson_decode.beltMap(decodeOnpingKey, Aeson_decode.string, OnpingKeyComparable, JSON.parse(" [[\"a\", \"A\"], [\"b\", \"B\"]] "))));
-                    }));
+        Jest.test("test", (function (param) {
+                return Jest.Expect.toEqual(Belt_Map.fromArray([
+                                [
+                                  /* OnpingKey */{
+                                    _0: "a"
+                                  },
+                                  "A"
+                                ],
+                                [
+                                  /* OnpingKey */{
+                                    _0: "b"
+                                  },
+                                  "B"
+                                ]
+                              ], OnpingKeyComparable), Jest.Expect.expect(Aeson_decode.beltMap(decodeOnpingKey, Aeson_decode.string, OnpingKeyComparable, JSON.parse(" [[\"a\", \"A\"], [\"b\", \"B\"]] "))));
+              }));
       }));
 
 Jest.describe("string Belt.Map.Int.t", (function (param) {
-        return Jest.test("test", (function (param) {
-                      return Jest.Expect.toEqual(Belt_MapInt.fromArray([
-                                      [
-                                        1,
-                                        "A"
-                                      ],
-                                      [
-                                        2,
-                                        "B"
-                                      ]
-                                    ]), Jest.Expect.expect(Aeson_decode.beltMapInt(Aeson_decode.string, JSON.parse(" {\"1\": \"A\", \"2\": \"B\"} "))));
-                    }));
+        Jest.test("test", (function (param) {
+                return Jest.Expect.toEqual(Belt_MapInt.fromArray([
+                                [
+                                  1,
+                                  "A"
+                                ],
+                                [
+                                  2,
+                                  "B"
+                                ]
+                              ]), Jest.Expect.expect(Aeson_decode.beltMapInt(Aeson_decode.string, JSON.parse(" {\"1\": \"A\", \"2\": \"B\"} "))));
+              }));
       }));
 
 Jest.describe("string Belt.Map.String.t", (function (param) {
-        return Jest.test("test", (function (param) {
-                      return Jest.Expect.toEqual(Belt_MapString.fromArray([
-                                      [
-                                        "a",
-                                        "A"
-                                      ],
-                                      [
-                                        "b",
-                                        "B"
-                                      ]
-                                    ]), Jest.Expect.expect(Aeson_decode.beltMapString(Aeson_decode.string, JSON.parse(" {\"a\": \"A\", \"b\": \"B\"} "))));
-                    }));
+        Jest.test("test", (function (param) {
+                return Jest.Expect.toEqual(Belt_MapString.fromArray([
+                                [
+                                  "a",
+                                  "A"
+                                ],
+                                [
+                                  "b",
+                                  "B"
+                                ]
+                              ]), Jest.Expect.expect(Aeson_decode.beltMapString(Aeson_decode.string, JSON.parse(" {\"a\": \"A\", \"b\": \"B\"} "))));
+              }));
       }));
 
 Jest.describe("dict", (function (param) {
@@ -814,27 +838,27 @@ Jest.describe("dict", (function (param) {
                                   return Aeson_decode.dict(Aeson_decode.string, param);
                                 }), JSON.parse(" { \"a\": null, \"b\": null } ")));
               }));
-        return throws(undefined, (function (param) {
-                      return Aeson_decode.dict(Aeson_decode.$$int, param);
-                    }), {
-                    hd: /* Bool */6,
+        throws(undefined, (function (param) {
+                return Aeson_decode.dict(Aeson_decode.$$int, param);
+              }), {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* Int */1,
+                  tl: {
+                    hd: /* String */2,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Null */3,
                       tl: {
-                        hd: /* Int */1,
-                        tl: {
-                          hd: /* String */2,
-                          tl: {
-                            hd: /* Null */3,
-                            tl: {
-                              hd: /* Array */4,
-                              tl: /* [] */0
-                            }
-                          }
-                        }
+                        hd: /* Array */4,
+                        tl: /* [] */0
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("field", (function (param) {
@@ -861,30 +885,30 @@ Jest.describe("field", (function (param) {
                                   return Aeson_decode.field("b", Aeson_decode.string, param);
                                 }), JSON.parse(" { \"a\": null, \"b\": null } ")));
               }));
-        return throws(undefined, (function (param) {
-                      return Aeson_decode.field("foo", Aeson_decode.$$int, param);
-                    }), {
-                    hd: /* Bool */6,
+        throws(undefined, (function (param) {
+                return Aeson_decode.field("foo", Aeson_decode.$$int, param);
+              }), {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* Int */1,
+                  tl: {
+                    hd: /* String */2,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Null */3,
                       tl: {
-                        hd: /* Int */1,
+                        hd: /* Array */4,
                         tl: {
-                          hd: /* String */2,
-                          tl: {
-                            hd: /* Null */3,
-                            tl: {
-                              hd: /* Array */4,
-                              tl: {
-                                hd: /* Object */5,
-                                tl: /* [] */0
-                              }
-                            }
-                          }
+                          hd: /* Object */5,
+                          tl: /* [] */0
                         }
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("at", (function (param) {
@@ -912,34 +936,34 @@ Jest.describe("at", (function (param) {
                                         return Aeson_decode.nullAs(partial_arg, param);
                                       }))(JSON.parse(" {\n        \"a\": { \"x\" : null }, \n        \"b\": null \n      } "))));
               }));
-        return throws(undefined, Aeson_decode.at({
-                        hd: "foo",
-                        tl: {
-                          hd: "bar",
-                          tl: /* [] */0
-                        }
-                      }, Aeson_decode.$$int), {
-                    hd: /* Bool */6,
+        throws(undefined, Aeson_decode.at({
+                  hd: "foo",
+                  tl: {
+                    hd: "bar",
+                    tl: /* [] */0
+                  }
+                }, Aeson_decode.$$int), {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* Int */1,
+                  tl: {
+                    hd: /* String */2,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Null */3,
                       tl: {
-                        hd: /* Int */1,
+                        hd: /* Array */4,
                         tl: {
-                          hd: /* String */2,
-                          tl: {
-                            hd: /* Null */3,
-                            tl: {
-                              hd: /* Array */4,
-                              tl: {
-                                hd: /* Object */5,
-                                tl: /* [] */0
-                              }
-                            }
-                          }
+                          hd: /* Object */5,
+                          tl: /* [] */0
                         }
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("optional", (function (param) {
@@ -956,7 +980,13 @@ Jest.describe("optional", (function (param) {
                 return Jest.Expect.toEqual(23, Jest.Expect.expect(Aeson_decode.optional(Aeson_decode.int32, 23)));
               }));
         Jest.test("int64 -> int64", (function (param) {
-                return Jest.Expect.toEqual(Caml_int64.mk(64, 0), Jest.Expect.expect(Aeson_decode.optional(Aeson_decode.int64_of_array, Caml_int64.mk(64, 0))));
+                return Jest.Expect.toEqual([
+                            0,
+                            64
+                          ], Jest.Expect.expect(Aeson_decode.optional(Aeson_decode.int64_of_array, [
+                                    0,
+                                    64
+                                  ])));
               }));
         Jest.test("string -> int", (function (param) {
                 return Jest.Expect.toEqual(undefined, Jest.Expect.expect(Aeson_decode.optional(Aeson_decode.$$int, "test")));
@@ -1013,13 +1043,13 @@ Jest.describe("optional", (function (param) {
                                       return Aeson_decode.optional(Aeson_decode.$$int, param);
                                     }), JSON.parse(" { \"x\": 2.3} "))));
               }));
-        return Jest.test("field optional - no such field", (function (param) {
-                      return Jest.Expect.toThrow(Jest.Expect.expectFn((function (param) {
-                                        return Aeson_decode.field("y", (function (param) {
-                                                      return Aeson_decode.optional(Aeson_decode.$$int, param);
-                                                    }), param);
-                                      }), JSON.parse(" { \"x\": 2} ")));
-                    }));
+        Jest.test("field optional - no such field", (function (param) {
+                return Jest.Expect.toThrow(Jest.Expect.expectFn((function (param) {
+                                  return Aeson_decode.field("y", (function (param) {
+                                                return Aeson_decode.optional(Aeson_decode.$$int, param);
+                                              }), param);
+                                }), JSON.parse(" { \"x\": 2} ")));
+              }));
       }));
 
 Jest.describe("optionalField", (function (param) {
@@ -1035,11 +1065,11 @@ Jest.describe("optionalField", (function (param) {
         Jest.test("optionalField - field does not exist", (function (param) {
                 return Jest.Expect.toEqual(undefined, Jest.Expect.expect(Aeson_decode.optionalField("y", Aeson_decode.$$int, JSON.parse(" { \"x\": 2} "))));
               }));
-        return Jest.test("field optional - no such field", (function (param) {
-                      return Jest.Expect.toThrow(Jest.Expect.expectFn((function (param) {
-                                        return Aeson_decode.optionalField("x", Aeson_decode.string, param);
-                                      }), JSON.parse(" { \"x\": 2} ")));
-                    }));
+        Jest.test("field optional - no such field", (function (param) {
+                return Jest.Expect.toThrow(Jest.Expect.expectFn((function (param) {
+                                  return Aeson_decode.optionalField("x", Aeson_decode.string, param);
+                                }), JSON.parse(" { \"x\": 2} ")));
+              }));
       }));
 
 Jest.describe("oneOf", (function (param) {
@@ -1075,27 +1105,27 @@ Jest.describe("oneOf", (function (param) {
           hd: Aeson_decode.$$int,
           tl: partial_arg_1
         };
-        return throws(undefined, (function (param) {
-                      return Aeson_decode.oneOf(partial_arg, param);
-                    }), {
-                    hd: /* Bool */6,
+        throws(undefined, (function (param) {
+                return Aeson_decode.oneOf(partial_arg, param);
+              }), {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* String */2,
+                  tl: {
+                    hd: /* Null */3,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Array */4,
                       tl: {
-                        hd: /* String */2,
-                        tl: {
-                          hd: /* Null */3,
-                          tl: {
-                            hd: /* Array */4,
-                            tl: {
-                              hd: /* Object */5,
-                              tl: /* [] */0
-                            }
-                          }
-                        }
+                        hd: /* Object */5,
+                        tl: /* [] */0
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("result", (function (param) {
@@ -1105,12 +1135,12 @@ Jest.describe("result", (function (param) {
                             _0: "hello"
                           }, Jest.Expect.expect(Aeson_decode.result(Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" {\"Error\": \"hello\"} "))));
               }));
-        return Jest.test("Error", (function (param) {
-                      return Jest.Expect.toEqual({
-                                  TAG: /* Ok */0,
-                                  _0: 2
-                                }, Jest.Expect.expect(Aeson_decode.result(Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" {\"Ok\": 2} "))));
-                    }));
+        Jest.test("Error", (function (param) {
+                return Jest.Expect.toEqual({
+                            TAG: /* Ok */0,
+                            _0: 2
+                          }, Jest.Expect.expect(Aeson_decode.result(Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" {\"Ok\": 2} "))));
+              }));
       }));
 
 Jest.describe("either", (function (param) {
@@ -1120,12 +1150,12 @@ Jest.describe("either", (function (param) {
                             _0: "hello"
                           }, Jest.Expect.expect(Aeson_decode.either(Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" {\"Right\": \"hello\"} "))));
               }));
-        return Jest.test("Left", (function (param) {
-                      return Jest.Expect.toEqual({
-                                  TAG: /* Left */0,
-                                  _0: 2
-                                }, Jest.Expect.expect(Aeson_decode.either(Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" {\"Left\": 2} "))));
-                    }));
+        Jest.test("Left", (function (param) {
+                return Jest.Expect.toEqual({
+                            TAG: /* Left */0,
+                            _0: 2
+                          }, Jest.Expect.expect(Aeson_decode.either(Aeson_decode.$$int, Aeson_decode.string, JSON.parse(" {\"Left\": 2} "))));
+              }));
       }));
 
 Jest.describe("tryEither", (function (param) {
@@ -1139,27 +1169,27 @@ Jest.describe("tryEither", (function (param) {
                                         return Aeson_decode.field("x", Aeson_decode.$$int, param);
                                       }))(23)));
               }));
-        return throws(undefined, Aeson_decode.tryEither(Aeson_decode.$$int, (function (param) {
-                          return Aeson_decode.field("x", Aeson_decode.$$int, param);
-                        })), {
-                    hd: /* Bool */6,
+        throws(undefined, Aeson_decode.tryEither(Aeson_decode.$$int, (function (param) {
+                    return Aeson_decode.field("x", Aeson_decode.$$int, param);
+                  })), {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* String */2,
+                  tl: {
+                    hd: /* Null */3,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Array */4,
                       tl: {
-                        hd: /* String */2,
-                        tl: {
-                          hd: /* Null */3,
-                          tl: {
-                            hd: /* Array */4,
-                            tl: {
-                              hd: /* Object */5,
-                              tl: /* [] */0
-                            }
-                          }
-                        }
+                        hd: /* Object */5,
+                        tl: /* [] */0
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("withDefault", (function (param) {
@@ -1181,9 +1211,9 @@ Jest.describe("withDefault", (function (param) {
         Jest.test("array", (function (param) {
                 return Jest.Expect.toEqual(0, Jest.Expect.expect(Aeson_decode.withDefault(0, Aeson_decode.$$int, [])));
               }));
-        return Jest.test("object", (function (param) {
-                      return Jest.Expect.toEqual(0, Jest.Expect.expect(Aeson_decode.withDefault(0, Aeson_decode.$$int, Aeson_encode.object_(/* [] */0))));
-                    }));
+        Jest.test("object", (function (param) {
+                return Jest.Expect.toEqual(0, Jest.Expect.expect(Aeson_decode.withDefault(0, Aeson_decode.$$int, Aeson_encode.object_(/* [] */0))));
+              }));
       }));
 
 Jest.describe("map", (function (param) {
@@ -1192,29 +1222,29 @@ Jest.describe("map", (function (param) {
                                       return 2 + param | 0;
                                     }), Aeson_decode.$$int, 23)));
               }));
-        return throws(undefined, (function (param) {
-                      return Aeson_decode.map((function (param) {
-                                    return 2 + param | 0;
-                                  }), Aeson_decode.$$int, param);
-                    }), {
-                    hd: /* Bool */6,
+        throws(undefined, (function (param) {
+                return Aeson_decode.map((function (param) {
+                              return 2 + param | 0;
+                            }), Aeson_decode.$$int, param);
+              }), {
+              hd: /* Bool */6,
+              tl: {
+                hd: /* Float */0,
+                tl: {
+                  hd: /* String */2,
+                  tl: {
+                    hd: /* Null */3,
                     tl: {
-                      hd: /* Float */0,
+                      hd: /* Array */4,
                       tl: {
-                        hd: /* String */2,
-                        tl: {
-                          hd: /* Null */3,
-                          tl: {
-                            hd: /* Array */4,
-                            tl: {
-                              hd: /* Object */5,
-                              tl: /* [] */0
-                            }
-                          }
-                        }
+                        hd: /* Object */5,
+                        tl: /* [] */0
                       }
                     }
-                  });
+                  }
+                }
+              }
+            });
       }));
 
 Jest.describe("andThen", (function (param) {
@@ -1264,14 +1294,14 @@ Jest.describe("andThen", (function (param) {
               hd: /* Float */0,
               tl: /* [] */0
             });
-        return throws("int to ", (function (param) {
-                      return Aeson_decode.andThen((function (param) {
-                                    return Aeson_decode.$$float;
-                                  }), Aeson_decode.$$int, param);
-                    }), {
-                    hd: /* Float */0,
-                    tl: /* [] */0
-                  });
+        throws("int to ", (function (param) {
+                return Aeson_decode.andThen((function (param) {
+                              return Aeson_decode.$$float;
+                            }), Aeson_decode.$$int, param);
+              }), {
+              hd: /* Float */0,
+              tl: /* [] */0
+            });
       }));
 
 Jest.describe("composite expressions", (function (param) {
@@ -1315,22 +1345,22 @@ Jest.describe("composite expressions", (function (param) {
                                               }), param);
                                 }), JSON.parse(" { \"a\": [[1, 2], \"foo\"], \"b\": [[4], [5, 6]] } ")));
               }));
-        return Jest.test("field", (function (param) {
-                      var json = JSON.parse(" { \"foo\": [1, 2, 3], \"bar\": \"baz\" } ");
-                      return Jest.Expect.toEqual([
-                                  [
-                                    1,
-                                    2,
-                                    3
-                                  ],
-                                  "baz"
-                                ], Jest.Expect.expect([
-                                      Aeson_decode.field("foo", (function (param) {
-                                              return Aeson_decode.array(Aeson_decode.$$int, param);
-                                            }), json),
-                                      Aeson_decode.field("bar", Aeson_decode.string, json)
-                                    ]));
-                    }));
+        Jest.test("field", (function (param) {
+                var json = JSON.parse(" { \"foo\": [1, 2, 3], \"bar\": \"baz\" } ");
+                return Jest.Expect.toEqual([
+                            [
+                              1,
+                              2,
+                              3
+                            ],
+                            "baz"
+                          ], Jest.Expect.expect([
+                                Aeson_decode.field("foo", (function (param) {
+                                        return Aeson_decode.array(Aeson_decode.$$int, param);
+                                      }), json),
+                                Aeson_decode.field("bar", Aeson_decode.string, json)
+                              ]));
+              }));
       }));
 
 exports.Test = Test;

--- a/lib/js/__tests__/Aeson_encode_test.js
+++ b/lib/js/__tests__/Aeson_encode_test.js
@@ -2,16 +2,15 @@
 
 var U = require("bs-zarith/lib/js/src/U.js");
 var Jest = require("@glennsl/bs-jest/lib/js/src/jest.js");
-var $$Array = require("bs-platform/lib/js/array.js");
+var $$Array = require("rescript/lib/js/array.js");
 var Bigint = require("bs-zarith/lib/js/src/Bigint.js");
-var Belt_Id = require("bs-platform/lib/js/belt_Id.js");
-var Js_dict = require("bs-platform/lib/js/js_dict.js");
-var Belt_Map = require("bs-platform/lib/js/belt_Map.js");
-var Caml_obj = require("bs-platform/lib/js/caml_obj.js");
-var Caml_int64 = require("bs-platform/lib/js/caml_int64.js");
-var Belt_MapInt = require("bs-platform/lib/js/belt_MapInt.js");
+var Belt_Id = require("rescript/lib/js/belt_Id.js");
+var Js_dict = require("rescript/lib/js/js_dict.js");
+var Belt_Map = require("rescript/lib/js/belt_Map.js");
+var Caml_obj = require("rescript/lib/js/caml_obj.js");
+var Belt_MapInt = require("rescript/lib/js/belt_MapInt.js");
 var Aeson_encode = require("../src/Aeson_encode.js");
-var Belt_MapString = require("bs-platform/lib/js/belt_MapString.js");
+var Belt_MapString = require("rescript/lib/js/belt_MapString.js");
 
 var Test = {};
 
@@ -19,7 +18,7 @@ function encodeOnpingKey(x) {
   return x._0;
 }
 
-var cmp = Caml_obj.caml_compare;
+var cmp = Caml_obj.compare;
 
 var OnpingKeyComparable = Belt_Id.MakeComparable({
       cmp: cmp
@@ -42,7 +41,7 @@ function encodePid(x) {
   return x._0;
 }
 
-var cmp$1 = Caml_obj.caml_compare;
+var cmp$1 = Caml_obj.compare;
 
 var PidComparable = Belt_Id.MakeComparable({
       cmp: cmp$1
@@ -84,11 +83,17 @@ Jest.test("int64_to_array", (function (param) {
         return Jest.Expect.toEqual([
                     0,
                     23
-                  ], Jest.Expect.expect(Caml_int64.mk(23, 0)));
+                  ], Jest.Expect.expect([
+                        0,
+                        23
+                      ]));
       }));
 
 Jest.test("int64_to_string", (function (param) {
-        return Jest.Expect.toEqual("23", Jest.Expect.expect(Aeson_encode.int64_to_string(Caml_int64.mk(23, 0))));
+        return Jest.Expect.toEqual("23", Jest.Expect.expect(Aeson_encode.int64_to_string([
+                            0,
+                            23
+                          ])));
       }));
 
 Jest.test("uint8", (function (param) {

--- a/lib/js/__tests__/Aeson_roundtrip_test.js
+++ b/lib/js/__tests__/Aeson_roundtrip_test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 var Jest = require("@glennsl/bs-jest/lib/js/src/jest.js");
-var Curry = require("bs-platform/lib/js/curry.js");
-var Belt_Id = require("bs-platform/lib/js/belt_Id.js");
-var Caml_obj = require("bs-platform/lib/js/caml_obj.js");
+var Curry = require("rescript/lib/js/curry.js");
+var Belt_Id = require("rescript/lib/js/belt_Id.js");
+var Caml_obj = require("rescript/lib/js/caml_obj.js");
 var Aeson_decode = require("../src/Aeson_decode.js");
 var Aeson_encode = require("../src/Aeson_encode.js");
-var Caml_js_exceptions = require("bs-platform/lib/js/caml_js_exceptions.js");
+var Caml_js_exceptions = require("rescript/lib/js/caml_js_exceptions.js");
 
 function resultMap(f, r) {
   if (r.TAG === /* Ok */0) {
@@ -31,7 +31,7 @@ function jsonRoundtripSpec(decode, encode, json) {
 }
 
 function cmp(a, b) {
-  return Caml_obj.caml_compare(a._0, b._0);
+  return Caml_obj.compare(a._0, b._0);
 }
 
 var PairKeyComparable = Belt_Id.MakeComparable({
@@ -109,37 +109,37 @@ function decodePairKeyMap(json) {
 }
 
 Jest.describe("Belt.Map.String.t", (function (param) {
-        return Jest.test("string key map", (function (param) {
-                      return jsonRoundtripSpec((function (param) {
-                                    return Aeson_decode.wrapResult((function (param) {
-                                                  return Aeson_decode.beltMapString(Aeson_decode.string, param);
-                                                }), param);
-                                  }), (function (param) {
-                                    return Aeson_encode.beltMapString((function (prim) {
-                                                  return prim;
-                                                }), param);
-                                  }), JSON.parse("{\"a\":\"A\",\"b\":\"B\"}"));
-                    }));
+        Jest.test("string key map", (function (param) {
+                return jsonRoundtripSpec((function (param) {
+                              return Aeson_decode.wrapResult((function (param) {
+                                            return Aeson_decode.beltMapString(Aeson_decode.string, param);
+                                          }), param);
+                            }), (function (param) {
+                              return Aeson_encode.beltMapString((function (prim) {
+                                            return prim;
+                                          }), param);
+                            }), JSON.parse("{\"a\":\"A\",\"b\":\"B\"}"));
+              }));
       }));
 
 Jest.describe("Belt.Map.Int.t", (function (param) {
-        return Jest.test("int key map", (function (param) {
-                      return jsonRoundtripSpec((function (param) {
-                                    return Aeson_decode.wrapResult((function (param) {
-                                                  return Aeson_decode.beltMapInt(Aeson_decode.string, param);
-                                                }), param);
-                                  }), (function (param) {
-                                    return Aeson_encode.beltMapInt((function (prim) {
-                                                  return prim;
-                                                }), param);
-                                  }), JSON.parse("{\"1\":\"A\",\"2\":\"B\"}"));
-                    }));
+        Jest.test("int key map", (function (param) {
+                return jsonRoundtripSpec((function (param) {
+                              return Aeson_decode.wrapResult((function (param) {
+                                            return Aeson_decode.beltMapInt(Aeson_decode.string, param);
+                                          }), param);
+                            }), (function (param) {
+                              return Aeson_encode.beltMapInt((function (prim) {
+                                            return prim;
+                                          }), param);
+                            }), JSON.parse("{\"1\":\"A\",\"2\":\"B\"}"));
+              }));
       }));
 
 Jest.describe("(pairKey, string, PairKeyComparable.identity) Belt.Map.t", (function (param) {
-        return Jest.test("custom key map", (function (param) {
-                      return jsonRoundtripSpec(decodePairKeyMap, encodePairKeyMap, JSON.parse("{\"pairKeyMap\":[[[0,\"a\"],\"A\"],[[1,\"b\"],\"B\"]]}"));
-                    }));
+        Jest.test("custom key map", (function (param) {
+                return jsonRoundtripSpec(decodePairKeyMap, encodePairKeyMap, JSON.parse("{\"pairKeyMap\":[[[0,\"a\"],\"A\"],[[1,\"b\"],\"B\"]]}"));
+              }));
       }));
 
 exports.resultMap = resultMap;

--- a/lib/js/examples/decode.js
+++ b/lib/js/examples/decode.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var $$Array = require("bs-platform/lib/js/array.js");
-var Curry = require("bs-platform/lib/js/curry.js");
-var Js_dict = require("bs-platform/lib/js/js_dict.js");
+var $$Array = require("rescript/lib/js/array.js");
+var Curry = require("rescript/lib/js/curry.js");
+var Js_dict = require("rescript/lib/js/js_dict.js");
 var Aeson_decode = require("../src/Aeson_decode.js");
-var Caml_js_exceptions = require("bs-platform/lib/js/caml_js_exceptions.js");
+var Caml_js_exceptions = require("rescript/lib/js/caml_js_exceptions.js");
 
 function mapJsonObjectString(f, decoder, encoder, str) {
   var json = JSON.parse(str);
@@ -12,8 +12,8 @@ function mapJsonObjectString(f, decoder, encoder, str) {
 }
 
 function sum(param) {
-  return $$Array.fold_left((function (prim, prim$1) {
-                return prim + prim$1 | 0;
+  return $$Array.fold_left((function (prim0, prim1) {
+                return prim0 + prim1 | 0;
               }), 0, param);
 }
 

--- a/lib/js/examples/encode.js
+++ b/lib/js/examples/encode.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Js_array = require("rescript/lib/js/js_array.js");
 var Aeson_encode = require("../src/Aeson_encode.js");
 
 console.log(JSON.stringify([
@@ -7,12 +8,12 @@ console.log(JSON.stringify([
           "bar"
         ]));
 
-console.log(JSON.stringify([
-            "foo",
-            "bar"
-          ].map(function (prim) {
-              return prim;
-            })));
+console.log(JSON.stringify(Js_array.map((function (prim) {
+                return prim;
+              }), [
+              "foo",
+              "bar"
+            ])));
 
 console.log(Aeson_encode.object_({
           hd: [

--- a/lib/js/src/Aeson_compatibility.js
+++ b/lib/js/src/Aeson_compatibility.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var Curry = require("bs-platform/lib/js/curry.js");
-var Caml_option = require("bs-platform/lib/js/caml_option.js");
-var Caml_js_exceptions = require("bs-platform/lib/js/caml_js_exceptions.js");
+var Curry = require("rescript/lib/js/curry.js");
+var Caml_option = require("rescript/lib/js/caml_option.js");
+var Caml_js_exceptions = require("rescript/lib/js/caml_js_exceptions.js");
 
 function left(a) {
   return {
@@ -87,11 +87,11 @@ function bind(m, k) {
 }
 
 function apply(f, v) {
-  return either(left, (function (f$prime) {
-                return either(left, (function (v$prime) {
+  return either(left, (function (f$p) {
+                return either(left, (function (v$p) {
                               return {
                                       TAG: /* Right */1,
-                                      _0: Curry._1(f$prime, v$prime)
+                                      _0: Curry._1(f$p, v$p)
                                     };
                             }), v);
               }), f);
@@ -149,8 +149,8 @@ function error(v) {
 function hush(v) {
   return either((function (param) {
                 
-              }), (function (v$prime) {
-                return Caml_option.some(v$prime);
+              }), (function (v$p) {
+                return Caml_option.some(v$p);
               }), v);
 }
 

--- a/lib/js/src/Aeson_decode.js
+++ b/lib/js/src/Aeson_decode.js
@@ -75,18 +75,6 @@ function int32(json) {
       };
 }
 
-function nativeint(json) {
-  var f = $$float(json);
-  if (_isInteger(f)) {
-    return f;
-  }
-  throw {
-        RE_EXN_ID: DecodeError,
-        _1: "Expected nativeint, got " + JSON.stringify(json),
-        Error: new Error()
-      };
-}
-
 function string(json) {
   if (typeof json === "string") {
     return json;
@@ -917,7 +905,7 @@ function int64(json) {
       if (exit === 2) {
         return Caml_format.caml_int64_of_string(s$1);
       }
-      
+
     } else {
       throw exn;
     }
@@ -935,7 +923,6 @@ exports.int32 = int32;
 exports.int64 = int64;
 exports.int64_of_array = int64_of_array;
 exports.int64_of_string = int64_of_string;
-exports.nativeint = nativeint;
 exports.uint8 = uint8;
 exports.uint16 = uint16;
 exports.uint32 = uint32;

--- a/lib/js/src/Aeson_decode.js
+++ b/lib/js/src/Aeson_decode.js
@@ -1,33 +1,33 @@
 'use strict';
 
 var U = require("bs-zarith/lib/js/src/U.js");
-var List = require("bs-platform/lib/js/list.js");
-var $$Array = require("bs-platform/lib/js/array.js");
-var Curry = require("bs-platform/lib/js/curry.js");
+var List = require("rescript/lib/js/list.js");
+var $$Array = require("rescript/lib/js/array.js");
+var Curry = require("rescript/lib/js/curry.js");
 var Bigint = require("bs-zarith/lib/js/src/Bigint.js");
-var Js_dict = require("bs-platform/lib/js/js_dict.js");
-var Js_json = require("bs-platform/lib/js/js_json.js");
-var Belt_Int = require("bs-platform/lib/js/belt_Int.js");
-var Belt_Map = require("bs-platform/lib/js/belt_Map.js");
-var Caml_array = require("bs-platform/lib/js/caml_array.js");
-var Caml_int64 = require("bs-platform/lib/js/caml_int64.js");
-var Belt_MapInt = require("bs-platform/lib/js/belt_MapInt.js");
-var Caml_format = require("bs-platform/lib/js/caml_format.js");
-var Caml_option = require("bs-platform/lib/js/caml_option.js");
-var Caml_string = require("bs-platform/lib/js/caml_string.js");
-var Belt_MapString = require("bs-platform/lib/js/belt_MapString.js");
-var Caml_exceptions = require("bs-platform/lib/js/caml_exceptions.js");
-var Caml_js_exceptions = require("bs-platform/lib/js/caml_js_exceptions.js");
+var Js_dict = require("rescript/lib/js/js_dict.js");
+var Js_json = require("rescript/lib/js/js_json.js");
+var Belt_Int = require("rescript/lib/js/belt_Int.js");
+var Belt_Map = require("rescript/lib/js/belt_Map.js");
+var Caml_array = require("rescript/lib/js/caml_array.js");
+var Caml_int64 = require("rescript/lib/js/caml_int64.js");
+var Belt_MapInt = require("rescript/lib/js/belt_MapInt.js");
+var Caml_format = require("rescript/lib/js/caml_format.js");
+var Caml_option = require("rescript/lib/js/caml_option.js");
+var Caml_string = require("rescript/lib/js/caml_string.js");
+var Belt_MapString = require("rescript/lib/js/belt_MapString.js");
+var Caml_exceptions = require("rescript/lib/js/caml_exceptions.js");
+var Caml_js_exceptions = require("rescript/lib/js/caml_js_exceptions.js");
 
 function _isInteger(value) {
-  if (isFinite(value)) {
+  if (Number.isFinite(value)) {
     return Math.floor(value) === value;
   } else {
     return false;
   }
 }
 
-var DecodeError = Caml_exceptions.create("Aeson_decode.DecodeError");
+var DecodeError = /* @__PURE__ */Caml_exceptions.create("Aeson_decode.DecodeError");
 
 function bool(json) {
   if (typeof json === "boolean") {
@@ -105,14 +105,14 @@ function isStringOfDigits(s) {
     return false;
   }
   var chars = explode(s);
-  var chars$prime = s.length > 1 && List.hd(chars) === /* "-" */45 ? List.tl(chars) : chars;
+  var chars$p = s.length > 1 && List.hd(chars) === /* '-' */45 ? List.tl(chars) : chars;
   return List.fold_right((function (c, x) {
                 if (isDigit(c)) {
                   return x;
                 } else {
                   return false;
                 }
-              }), chars$prime, true);
+              }), chars$p, true);
 }
 
 function uint8(json) {
@@ -180,7 +180,7 @@ function uint64(json) {
 function int64_of_string(json) {
   if (typeof json === "string") {
     if (isStringOfDigits(json)) {
-      return Caml_format.caml_int64_of_string(json);
+      return Caml_format.int64_of_string(json);
     }
     throw {
           RE_EXN_ID: DecodeError,
@@ -216,7 +216,7 @@ function bigint(json) {
 function date(json) {
   if (typeof json === "string") {
     var encodedDate = new Date(json);
-    if (isNaN(encodedDate.getTime())) {
+    if (Number.isNaN(encodedDate.getTime())) {
       throw {
             RE_EXN_ID: DecodeError,
             _1: "Expected date, got " + json,
@@ -607,7 +607,7 @@ function beltMapInt(decodeValue, json) {
   }
   return Belt_MapInt.fromArray($$Array.map((function (param) {
                     return [
-                            Caml_format.caml_int_of_string(param[0]),
+                            Caml_format.int_of_string(param[0]),
                             param[1]
                           ];
                   }), Js_dict.entries(decoded_dict)));
@@ -640,7 +640,7 @@ function field(key, decode, json) {
     }
     throw {
           RE_EXN_ID: DecodeError,
-          _1: "Expected field \'" + key + "\'",
+          _1: "Expected field '" + key + "'",
           Error: new Error()
         };
   }
@@ -903,14 +903,14 @@ function int64(json) {
         throw exn$1;
       }
       if (exit === 2) {
-        return Caml_format.caml_int64_of_string(s$1);
+        return Caml_format.int64_of_string(s$1);
       }
-
+      
     } else {
       throw exn;
     }
   }
-  return Caml_format.caml_int64_of_string(s);
+  return Caml_format.int64_of_string(s);
 }
 
 var tuple2 = pair;

--- a/lib/js/src/Aeson_encode.js
+++ b/lib/js/src/Aeson_encode.js
@@ -1,16 +1,17 @@
 'use strict';
 
 var U = require("bs-zarith/lib/js/src/U.js");
-var List = require("bs-platform/lib/js/list.js");
-var $$Array = require("bs-platform/lib/js/array.js");
-var Curry = require("bs-platform/lib/js/curry.js");
-var Int64 = require("bs-platform/lib/js/int64.js");
+var List = require("rescript/lib/js/list.js");
+var $$Array = require("rescript/lib/js/array.js");
+var Curry = require("rescript/lib/js/curry.js");
+var Int64 = require("rescript/lib/js/int64.js");
 var Bigint = require("bs-zarith/lib/js/src/Bigint.js");
-var Js_dict = require("bs-platform/lib/js/js_dict.js");
-var Belt_Map = require("bs-platform/lib/js/belt_Map.js");
-var Belt_MapInt = require("bs-platform/lib/js/belt_MapInt.js");
-var Caml_option = require("bs-platform/lib/js/caml_option.js");
-var Belt_MapString = require("bs-platform/lib/js/belt_MapString.js");
+var Js_dict = require("rescript/lib/js/js_dict.js");
+var Belt_Map = require("rescript/lib/js/belt_Map.js");
+var Js_string = require("rescript/lib/js/js_string.js");
+var Belt_MapInt = require("rescript/lib/js/belt_MapInt.js");
+var Caml_option = require("rescript/lib/js/caml_option.js");
+var Belt_MapString = require("rescript/lib/js/belt_MapString.js");
 
 var int64_to_string = Int64.to_string;
 
@@ -71,7 +72,7 @@ function optionalField(fieldName, encode, optionalValue) {
 }
 
 function date(d) {
-  return d.toISOString().replace(".000Z", "Z");
+  return Js_string.replace(".000Z", "Z", d.toISOString());
 }
 
 var object_ = Js_dict.fromList;

--- a/package.json
+++ b/package.json
@@ -4,10 +4,15 @@
   "description": "BuckleScript JSON serializations that match Haskell aeson",
   "main": "index.js",
   "scripts": {
-    "build": "bsb -make-world",
-    "clean": "bsb -clean-world",
-    "test": "npm run build && jest && npm run test:examples",
-    "test:examples": "npm run build && ./run_examples.sh"
+    "build": "yarn clean && yarn run re:build",
+    "build-dirty": "yarn run re:build",    
+    "clean": "rescript clean",
+    "start": "yarn run dev | yarn run re:watch",    
+    "test": "yarn run re:build && yarn run jest",
+    "test:examples": "yarn run re:build && ./run_examples.sh",
+    "re:watch": "rescript build -w",
+    "re:build": "rescript build",
+    "re:build-deps": "rescript build -with-deps"
   },
   "repository": {
     "type": "git",
@@ -29,6 +34,6 @@
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.9",
-    "bs-platform": "^10.0.1"
+    "rescript": "^10.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   },
   "homepage": "https://github.com/plow-technologies/bs-aeson#readme",
   "dependencies": {
-    "bs-zarith": "^3.1.0"
+    "bs-zarith": "^3.2.0"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.9",
-    "bs-platform": "^8.4.2"
+    "bs-platform": "^10.0.1"
   }
 }

--- a/src/Aeson_decode.ml
+++ b/src/Aeson_decode.ml
@@ -7,40 +7,33 @@ type 'a decoder = Js.Json.t -> 'a
 
 exception DecodeError of string
 
-let bool json = 
+let bool json =
   if Js.typeof json = "boolean" then
     (Obj.magic (json : Js.Json.t) : bool)
   else
     raise @@ DecodeError ("Expected boolean, got " ^ Js.Json.stringify json)
 
-let float json = 
+let float json =
   if Js.typeof json = "number" then
     (Obj.magic (json : Js.Json.t) : float)
   else
     raise @@ DecodeError ("Expected number, got " ^ Js.Json.stringify json)
 
-let int json = 
+let int json =
   let f = float json in
   if _isInteger f then
     (Obj.magic (f : float) : int)
   else
     raise @@ DecodeError ("Expected int, got " ^ Js.Json.stringify json)
 
-let int32 json = 
+let int32 json =
   let f = float json in
   if _isInteger f then
     (Obj.magic (f : float) : int32)
   else
     raise @@ DecodeError ("Expected int32, got " ^ Js.Json.stringify json)
-  
-let nativeint json = 
-  let f = float json in
-  if _isInteger f then
-    (Obj.magic (f : float) : nativeint)
-  else
-    raise @@ DecodeError ("Expected nativeint, got " ^ Js.Json.stringify json)
 
-let string json = 
+let string json =
   if Js.typeof json = "string" then
     (Obj.magic (json : Js.Json.t) : string)
   else
@@ -72,14 +65,14 @@ let uint8 json =
   if _isInteger f then
     U.UInt8.ofInt (Obj.magic (f : float) : int)
   else
-    raise @@ DecodeError ("Expected int, got " ^ Js.Json.stringify json)  
+    raise @@ DecodeError ("Expected int, got " ^ Js.Json.stringify json)
 
 let uint16 json =
   let f = float json in
   if _isInteger f then
     U.UInt16.ofInt (Obj.magic (f : float) : int)
   else
-    raise @@ DecodeError ("Expected int, got " ^ Js.Json.stringify json)  
+    raise @@ DecodeError ("Expected int, got " ^ Js.Json.stringify json)
 
 let uint32 json =
   match int json with
@@ -98,23 +91,23 @@ let uint64 json =
 let int64_of_string json =
   if Js.typeof json = "string" then
     let source = (Obj.magic (json : Js.Json.t) : string) in
-    
+
     if isStringOfDigits source
     then Int64.of_string source
     else raise @@ DecodeError ("Expected int64, got " ^ source)
   else
     raise @@ DecodeError ("Expected int64, got " ^ Js.Json.stringify json)
-  
+
 let bigint json =
   if Js.typeof json = "string" then
     let source = (Obj.magic (json : Js.Json.t) : string) in
-    
+
     if isStringOfDigits source
     then Bigint.of_string source
     else raise @@ DecodeError ("Expected Bigint.t, got " ^ source)
   else
     raise @@ DecodeError ("Expected Bigint.t, got " ^ Js.Json.stringify json)
-  
+
 let date json =
   if Js.typeof json = "string" then
     let source = (Obj.magic (json : Js.Json.t) : string) in
@@ -124,7 +117,7 @@ let date json =
     else encodedDate
   else
     raise @@ DecodeError ("Expected date, got " ^ Js.Json.stringify json)
-    
+
 let nullable decode json =
   if (Obj.magic json : 'a Js.null) == Js.null then
     Js.null
@@ -132,13 +125,13 @@ let nullable decode json =
     Js.Null.return (decode json)
 
 (* TODO: remove this? *)
-let nullAs value json = 
+let nullAs value json =
   if (Obj.magic json : 'a Js.null) == Js.null then
     value
-  else 
+  else
     raise @@ DecodeError ("Expected null, got " ^ Js.Json.stringify json)
 
-let array decode json = 
+let array decode json =
   if Js.Array.isArray json then begin
     let source = (Obj.magic (json : Js.Json.t) : Js.Json.t array) in
     let length = Js.Array.length source in
@@ -299,7 +292,7 @@ let tuple9 first second third fourth fifth sixth seventh eighth ninth json =
       raise @@ DecodeError ({j|Expected array of length 9, got array of length $length|j})
   end
   else
-    raise @@ DecodeError ("Expected array, got " ^ Js.Json.stringify json)  
+    raise @@ DecodeError ("Expected array, got " ^ Js.Json.stringify json)
 
 let tuple10 first second third fourth fifth sixth seventh eighth ninth tenth json =
   if Js.Array.isArray json then begin
@@ -321,8 +314,8 @@ let tuple10 first second third fourth fifth sixth seventh eighth ninth tenth jso
       raise @@ DecodeError ({j|Expected array of length 10, got array of length $length|j})
   end
   else
-    raise @@ DecodeError ("Expected array, got " ^ Js.Json.stringify json)  
-  
+    raise @@ DecodeError ("Expected array, got " ^ Js.Json.stringify json)
+
 let singleEnumerator a json =
   if Js.Array.isArray json then begin
     let source = (Obj.magic (json : Js.Json.t) : Js.Json.t array) in
@@ -335,9 +328,9 @@ let singleEnumerator a json =
   else
     raise @@ DecodeError ("Expected array, got " ^ Js.Json.stringify json)
 
-let dict decode json = 
-  if Js.typeof json = "object" && 
-      not (Js.Array.isArray json) && 
+let dict decode json =
+  if Js.typeof json = "object" &&
+      not (Js.Array.isArray json) &&
       not ((Obj.magic json : 'a Js.null) == Js.null)
   then begin
     let source = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
@@ -380,8 +373,8 @@ let beltMapString decodeValue json =
     | exception DecodeError _ -> raise @@ DecodeError ({j|Expected an associative array with keys as strings|j})
 
 let field key decode json =
-  if Js.typeof json = "object" && 
-      not (Js.Array.isArray json) && 
+  if Js.typeof json = "object" &&
+      not (Js.Array.isArray json) &&
       not ((Obj.magic json : 'a Js.null) == Js.null)
   then begin
     let dict = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
@@ -393,8 +386,8 @@ let field key decode json =
     raise @@ DecodeError ("Expected object, got " ^ Js.Json.stringify json)
 
 let optionalField key decode json =
-  if Js.typeof json = "object" && 
-      not (Js.Array.isArray json) && 
+  if Js.typeof json = "object" &&
+      not (Js.Array.isArray json) &&
       not ((Obj.magic json : 'a Js.null) == Js.null)
   then begin
     let dict = (Obj.magic (json : Js.Json.t) : Js.Json.t Js.Dict.t) in
@@ -407,9 +400,9 @@ let optionalField key decode json =
     raise @@ DecodeError ("Expected object, got " ^ Js.Json.stringify json)
 
 let rec at key_path decoder =
-    match key_path with 
+    match key_path with
       | [key] -> field key decoder
-      | first::rest -> field first (at rest decoder) 
+      | first::rest -> field first (at rest decoder)
       | [] -> raise @@ Invalid_argument ("Expected key_path to contain at least one element")
 
 let optional decode json =
@@ -429,7 +422,7 @@ let result decodeA decodeB json =
     )
   )
   | None -> raise @@ DecodeError ("Expected object with a \"Ok\" key or \"Error\" key, got " ^ Js.Json.stringify json)
-  
+
 let either decodeL decodeR json =
   match Js.Json.decodeObject json with
   | Some o -> (
@@ -443,7 +436,7 @@ let either decodeL decodeR json =
   )
   | None -> raise @@ DecodeError ("Expected object with a \"Left\" key or \"Right\" key, got " ^ Js.Json.stringify json)
 
-       
+
 let rec oneOf decoders json =
   match decoders with
   | [] ->
@@ -453,7 +446,7 @@ let rec oneOf decoders json =
     match decode json with
     | v -> v
     | exception _ -> oneOf rest json
-                   
+
 let tryEither a b =
   oneOf [a;b]
 
@@ -478,7 +471,7 @@ let wrapResult decoder json =
   | v -> Belt.Result.Ok v
   | exception DecodeError message -> Belt.Result.Error message
 
-let int64_of_array json = 
+let int64_of_array json =
   let fs = array float json in
   if Array.length fs = 2 then
     if (_isInteger (Array.get fs 0) && _isInteger (Array.get fs 1)) then
@@ -492,7 +485,7 @@ let int64_of_array json =
   else
     raise @@ DecodeError ("Expected int64, got " ^ Js.Json.stringify json)
 
-let int64 json = 
+let int64 json =
   match string json with
   | s -> Int64.of_string s
   | exception DecodeError _ ->

--- a/src/Aeson_decode.mli
+++ b/src/Aeson_decode.mli
@@ -1,6 +1,6 @@
 (** Provides a set of low level combinator primitives to decode Js.Json.t data
 structures
-A decoder combinator will return the decoded value if successful, or raise a 
+A decoder combinator will return the decoded value if successful, or raise a
 [DecodeError of string] if unsuccessful, where the string argument contains the
 error message.
 Decoders are designed to be combined to produce more complex decoders that can
@@ -17,10 +17,10 @@ exception DecodeError of string
 
 val bool : bool decoder
 (** Decodes a JSON value into a [bool]
-    
+
 {b Returns} a [bool] if the JSON value is a number.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -37,10 +37,10 @@ val bool : bool decoder
 
 val float : float decoder
 (** Decodes a JSON value into a [float]
-    
+
 {b Returns} a [float] if the JSON value is a number.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -57,10 +57,10 @@ val float : float decoder
 
 val int : int decoder
 (** Decodes a JSON value into an [int]
-    
+
 {b Returns} an [int] if the JSON value is a number.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -86,9 +86,6 @@ val int64_of_array : int64 decoder
 
 val int64_of_string : int64 decoder
 (** Decodes a JSON value into an [int64] *)
-  
-val nativeint : nativeint decoder
-(** Decodes a JSON value into an [nativeint] *)
 
 val uint8 : U.UInt8.t decoder
 (** Decodes a JSON value into an [U.UInt8.t] *)
@@ -104,13 +101,13 @@ val uint64 : U.UInt64.t decoder
 
 val bigint : Bigint.t decoder
 (** Decodes a JSON value into an [Bigint.t] *)
-  
+
 val string : string decoder
 (** Decodes a JSON value into a [string]
-    
+
 {b Returns} a [string] if the JSON value is a number.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -125,14 +122,14 @@ val string : string decoder
 
 val date : Js_date.t decoder
 
-  
+
 val nullable : 'a decoder -> 'a Js.null decoder
 (** Decodes a JSON value into an ['a Js.null]
-    
+
 {b Returns} [Js.null] if the JSON value is [null], or an ['a Js.null] if the
 given decoder succeeds,
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -147,10 +144,10 @@ given decoder succeeds,
 
 val nullAs : 'a -> 'a decoder
 (** Returns the given value if the JSON value is [null]
-    
+
 {b Returns} an ['a] if the JSON value is [null].
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -165,11 +162,11 @@ val nullAs : 'a -> 'a decoder
 
 val array : 'a decoder -> 'a array decoder
 (** Decodes a JSON array into an ['a array] using the given decoder on each element
-    
+
 {b Returns} an ['a array] if the JSON value is a JSON array and all its
 elements are successfully decoded.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -185,7 +182,7 @@ elements are successfully decoded.
 *)
 
 val beltMap : 'k decoder -> 'v decoder -> id:('k, 'c) Belt.Map.id -> (('k, 'v, 'c) Belt.Map.t) decoder
-(** [beltMap k v m] 
+(** [beltMap k v m]
     Decodes a JSON array of a JSON array with two elements into a ('k , 'v, 'id) Belt.Map.t
     using the k and v decodes.
  *)
@@ -198,11 +195,11 @@ val beltMapString : 'v decoder -> ('v Belt.Map.String.t) decoder
 
 val list : 'a decoder -> 'a list decoder
 (** Decodes a JSON array into an ['a list] using the given decoder on each element
-    
+
 {b Returns} an ['a list] if the JSON value is a JSON array and all its
 elements are successfully decoded.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -254,16 +251,16 @@ val tuple8 : 'a decoder -> 'b decoder -> 'c decoder -> 'd decoder -> 'e decoder 
 val tuple9 : 'a decoder -> 'b decoder -> 'c decoder -> 'd decoder -> 'e decoder -> 'f decoder -> 'g decoder -> 'h decoder -> 'i decoder -> ('a * 'b * 'c * 'd * 'e * 'f * 'g * 'h * 'i) decoder
 
 val tuple10 : 'a decoder -> 'b decoder -> 'c decoder -> 'd decoder -> 'e decoder -> 'f decoder -> 'g decoder -> 'h decoder -> 'i decoder -> 'j decoder -> ('a * 'b * 'c * 'd * 'e * 'f * 'g * 'h * 'i * 'j) decoder
-  
+
 val singleEnumerator : 'a -> Js.Json.t -> 'a
-  
+
 val dict : 'a decoder -> 'a Js.Dict.t decoder
 (** Decodes a JSON object into a dict using the given decoder on each of its values
-    
+
 {b Returns} an ['a Js.Dict.t] if the JSON value is a JSON object and all its
 values are successfully decoded.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -280,11 +277,11 @@ values are successfully decoded.
 
 val field : string -> 'a decoder -> 'a decoder
 (** Decodes a JSON object with a specific field into the value of that field
-    
+
 {b Returns} an ['a] if the JSON value is a JSON object with the given field
 and a value that is successfully decoded with the given decoder.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -305,16 +302,16 @@ val optionalField : string -> 'a decoder -> 'a option decoder
 (** Decodes a JSON object with a specific field into the value of that field
     if the field exists
 
-@raise [DecodeError] if the field exists but the decoder is unsuccessful 
+@raise [DecodeError] if the field exists but the decoder is unsuccessful
 *)
 
 val at : string list -> 'a decoder -> 'a decoder
 (** Same as [field] but takes a top level field and a list of nested fields for decoding nested values.
-    
+
 {b Returns} an ['a] if the JSON value is a JSON object with the given field
 and a value that is successfully decoded with the given decoder.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -327,7 +324,7 @@ and a value that is successfully decoded with the given decoder.
 
 val optional : 'a decoder -> 'a option decoder
 (** Maps a decoder [result] to an option
-    
+
 {b Returns} [Some of 'a] if the given decoder is successful, [None] if
 it is not.
 
@@ -362,13 +359,13 @@ a composite decoder, and is useful to decode optional JSON object fields.
 val result : 'a decoder -> 'b decoder -> ('a, 'b) Belt.Result.t decoder
 
 val either : 'l decoder -> 'r decoder -> ('l, 'r) Aeson_compatibility.Either.t decoder
-  
+
 val oneOf : 'a decoder list -> 'a decoder
 (** Tries each [decoder] in order, retunring the result of the first that succeeds
 
 {b Returns} an ['a] if one of the decoders succeed.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -381,14 +378,14 @@ val oneOf : 'a decoder list -> 'a decoder
 ]}
 *)
 
-  
+
 val tryEither : 'a decoder -> 'a decoder -> 'a decoder
 
 (** Tries each [decoder] in order, returning the result of the first that succeeds
 
 {b Returns} an ['a] if one of the decoders succeed.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -406,7 +403,7 @@ val withDefault : 'a -> 'a decoder -> 'a decoder
 
 {b Returns} an ['a] if one of the decoders succeed.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -424,7 +421,7 @@ val map : ('a -> 'b) -> 'a decoder -> 'b decoder
 
 {b Returns} a ['b] if the given decoder succeeds.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   open Json
@@ -438,7 +435,7 @@ val andThen : ('a -> 'b decoder) -> 'a decoder -> 'b decoder
 
 {b Returns} an ['a] if both decoders succeed.
 
-@raise [DecodeError] if unsuccessful 
+@raise [DecodeError] if unsuccessful
 
 @example {[
   (* Deoce a JSON tree structure *)
@@ -477,7 +474,7 @@ val andThen : ('a -> 'b decoder) -> 'a decoder -> 'b decoder
 
   let myTree =
     json
-    |> Js.Json.parseExn 
+    |> Js.Json.parseExn
     |> decodeTree int
 ]}
 *)

--- a/src/Aeson_encode.ml
+++ b/src/Aeson_encode.ml
@@ -6,24 +6,23 @@ external float : float -> Js.Json.t = "%identity"
 external int : int -> Js.Json.t = "%identity"
 external int32 : int32 -> Js.Json.t = "%identity"
 external int64_to_array : int64 -> Js.Json.t = "%identity"
-external nativeint : nativeint -> Js.Json.t = "%identity"
-external bool : bool -> Js.Json.t = "%identity" 
+external bool : bool -> Js.Json.t = "%identity"
 external dict : Js.Json.t Js_dict.t -> Js.Json.t = "%identity"
-                                                 
+
 let int64_to_string (x: Int64.t) = string (Int64.to_string x)
-                                                 
+
 let bigint (x: Bigint.t) = string (Bigint.to_string x)
-                                                 
+
 let uint8 (x: U.UInt8.t) = int (U.UInt8.toInt x)
 
 let uint16 (x: U.UInt16.t) = int (U.UInt16.toInt x)
 
 (* underlying it is an int64 but is less than JS limit,
-   haskell expects a numeric literal *)                           
+   haskell expects a numeric literal *)
 let uint32 (x: U.UInt32.t) = int (U.UInt32.toInt x)
 
 let uint64 (x: U.UInt64.t) = string (U.UInt64.toString x)
-  
+
 let nullable encode = function
   | None -> null
   | Some v -> encode v
@@ -42,9 +41,9 @@ let optionalField fieldName encode optionalValue =
   | Some value -> [(fieldName, encode value)]
   | None -> []
 
-(* Haskell aeson renders .000Z as Z *)          
+(* Haskell aeson renders .000Z as Z *)
 let date d: Js.Json.t = string (Js.String.replace ".000Z" "Z" (Js_date.toISOString d))
-  
+
 let object_ props: Js.Json.t =
   props |> Js.Dict.fromList
         |> dict

--- a/src/Aeson_encode.mli
+++ b/src/Aeson_encode.mli
@@ -21,28 +21,25 @@ external int32 : int32 -> Js.Json.t = "%identity"
 external int64_to_array : int64 -> Js.Json.t = "%identity"
 (** [int64 n] makes a JSON number of the [int64] [n] in the format of [high, low] where high is signed and low is unsigned *)
 
-external nativeint : nativeint -> Js.Json.t = "%identity"
-(** [nativeint n] makes a JSON number of the [nativeint] [n] *)
-
 val int64_to_string : Int64.t -> Js.Json.t
 (** [int64 n] makes a JSON number of the [int64] [n] in the format of a string *)
-                                                 
-val bigint : Bigint.t -> Js.Json.t                                                 
+
+val bigint : Bigint.t -> Js.Json.t
 (** [bigint n] makes a JSON number of the [Bigint.t] [n] in the format of a string *)
 
 val uint8 : U.UInt8.t -> Js.Json.t
 (** [uint8 n] makes a JSON number of the [U.UInt8.t] [n] *)
-                           
+
 val uint16 : U.UInt16.t -> Js.Json.t
 (** [uint16 n] makes a JSON number of the [U.UInt8.t] [n] *)
-                           
+
 val uint32 : U.UInt32.t -> Js.Json.t
 (** [uint32 n] makes a JSON number of the [U.UInt32.t] [n] in the format of a string *)
 
 val uint64 : U.UInt64.t -> Js.Json.t
 (** [uint64 n] makes a JSON number of the [U.UInt64.t] [n] in the format of a string *)
-                                            
-external bool : bool -> Js.Json.t = "%identity" 
+
+external bool : bool -> Js.Json.t = "%identity"
 (** [bool b] makes a JSON boolean of the [Js.bool] [b] *)
 
 val nullable : 'a encoder -> 'a option -> Js.Json.t
@@ -64,7 +61,7 @@ val optional : 'a encoder -> 'a option -> Js.Json.t
 (** [optional encoder a] returns the encoded value in Some, or null if Nothing *)
 
 val optionalField : string -> 'a encoder -> 'a option -> (string * Js.Json.t) list
-(** [optionalField encoder fieldName a] returns the encoded value with the 
+(** [optionalField encoder fieldName a] returns the encoded value with the
     fieldName in a list, or an empty list if None *)
 
 val date : Js_date.t encoder
@@ -82,9 +79,9 @@ val beltMapString : 'v encoder -> 'v Belt.Map.String.t -> Js.Json.t
 val list : 'a encoder -> 'a list encoder
 (** [list encoder l] makes a JSON array of the [list] [l] using the given [encoder] *)
 
-(** The functions below are specialized for specific array type which 
+(** The functions below are specialized for specific array type which
     happened to be already JSON object in the BuckleScript runtime. Therefore
-    they are more efficient (constant time rather than linear conversion). *) 
+    they are more efficient (constant time rather than linear conversion). *)
 
 val pair : 'a encoder -> 'b encoder -> ('a * 'b) -> Js.Json.t
 
@@ -93,7 +90,7 @@ val tuple2 : 'a encoder -> 'b encoder -> ('a * 'b) -> Js.Json.t
 val tuple3 : 'a encoder -> 'b encoder -> 'c encoder -> ('a * 'b * 'c) -> Js.Json.t
 
 val tuple4 : 'a encoder -> 'b encoder -> 'c encoder -> 'd encoder -> ('a * 'b * 'c * 'd) -> Js.Json.t
-  
+
 val tuple5 : 'a encoder -> 'b encoder -> 'c encoder -> 'd encoder -> 'e encoder -> ('a * 'b * 'c * 'd * 'e) -> Js.Json.t
 
 val tuple6 : 'a encoder -> 'b encoder -> 'c encoder -> 'd encoder -> 'e encoder -> 'f encoder -> ('a * 'b * 'c * 'd * 'e * 'f) -> Js.Json.t
@@ -105,16 +102,16 @@ val tuple8 : 'a encoder -> 'b encoder -> 'c encoder -> 'd encoder -> 'e encoder 
 val tuple9 : 'a encoder -> 'b encoder -> 'c encoder -> 'd encoder -> 'e encoder -> 'f encoder -> 'g encoder -> 'h encoder -> 'i encoder -> ('a * 'b * 'c * 'd * 'e * 'f * 'g * 'h * 'i) -> Js.Json.t
 
 val tuple10 : 'a encoder -> 'b encoder -> 'c encoder -> 'd encoder -> 'e encoder -> 'f encoder -> 'g encoder -> 'h encoder -> 'i encoder -> 'j encoder -> ('a * 'b * 'c * 'd * 'e * 'f * 'g * 'h * 'i * 'j) -> Js.Json.t
-  
+
 val result : 'a encoder -> 'b encoder -> ('a, 'b) Belt.Result.t -> Js.Json.t
 
 val either : 'l encoder -> 'r encoder -> ('l, 'r) Aeson_compatibility.Either.t -> Js.Json.t
 
 val singleEnumerator : 'a encoder
 (** [singleEnumerator a] takes a value and returns an empty JSON array. Useful for encoding a single enumerator that matches Haskell aeson. *)
-  
+
 external stringArray : string array -> Js.Json.t = "%identity"
-(** [stringArray a] makes a JSON array of the [string array] [a] *) 
+(** [stringArray a] makes a JSON array of the [string array] [a] *)
 
 external numberArray : float array -> Js.Json.t = "%identity"
 (** [numberArray a] makes a JSON array of the [float array] [a] *)

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,11 +667,6 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
-bs-platform@^10.0.1:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-9.0.2.tgz#a6eac70eb8924a322556dacaccbfbc9b2a0d3a37"
-  integrity sha512-Ye9JqJ4Oa7mcjjoOVRYI8Uc2Cf8N7jQLWDcdUplY7996d/YErSR7WitmV7XnSwr4EvdrbwjEsg1NxNjUQv3ChA==
-
 bs-zarith@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/bs-zarith/-/bs-zarith-3.2.0.tgz#fdaa73c322f0e27cd92eab33fc984228b3791b3c"
@@ -2691,6 +2686,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+rescript@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/rescript/-/rescript-10.0.1.tgz#5b2da8a8bcfb994bed1eb24820bf10cfb9d8c440"
+  integrity sha512-XwO1GPDtoEU4H03xQE5bp0/qtSVR6YLaJRPxWKrfFgKc+LI36ODOCie7o9UJfgzQdoMYkkZyiTGZ4N9OQEaiUw==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,15 +667,15 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
-bs-platform@^8.4.2:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-8.4.2.tgz#778dabd1dfb3bc95e0086c58dabae74e4ebdee8a"
-  integrity sha512-9q7S4/LLV/a68CweN382NJdCCr/lOSsJR3oQYnmPK98ChfO/AdiA3lYQkQTp6T+U0I5Z5RypUAUprNstwDtMDQ==
+bs-platform@^10.0.1:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-9.0.2.tgz#a6eac70eb8924a322556dacaccbfbc9b2a0d3a37"
+  integrity sha512-Ye9JqJ4Oa7mcjjoOVRYI8Uc2Cf8N7jQLWDcdUplY7996d/YErSR7WitmV7XnSwr4EvdrbwjEsg1NxNjUQv3ChA==
 
-bs-zarith@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/bs-zarith/-/bs-zarith-3.1.0.tgz#8550b63826d8da23e0ce8a2694fc39040c6a34ce"
-  integrity sha512-RlOAC40DMBy/5i6nh1RP5URqQAoisKlzVf4JzcCHvIuwT1/DLc/60DcnFNU1lftgtdCBGuqyb6WyzJ+ycNDB8w==
+bs-zarith@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/bs-zarith/-/bs-zarith-3.2.0.tgz#fdaa73c322f0e27cd92eab33fc984228b3791b3c"
+  integrity sha512-cYc/ni6e2fQRpTiwut/UwWdRjeCOZ/qfLiEv3YKKE9xgBL5yccXIb7mHhJG1Q1DX8sJnjvQllrTnjjXMfv1AdQ==
 
 bser@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
`nativeint` is no longer supported in order to upgrade to Rescript v10 soon. This also upgrade the `bs-zarith` dependency.